### PR TITLE
changes to LmcpGen python generation process to change the format of …

### DIFF
--- a/src/avtas/lmcp/lmcpgen/PythonMethods.java
+++ b/src/avtas/lmcp/lmcpgen/PythonMethods.java
@@ -592,7 +592,6 @@ class PythonMethods {
 
         return str;
     }
-    
     public static String to_dict_members(MDMInfo[] infos, MDMInfo info, File outfile, StructInfo st, EnumInfo en, String ws) throws Exception {
         String str = "";
         str += ws + extends_name(infos, info, outfile, st, en, "") + ".toDictMembers(self, d)\n";
@@ -679,11 +678,17 @@ class PythonMethods {
     }
     
     public static String members_from_dict(MDMInfo[] infos, MDMInfo info, File outfile, StructInfo st, EnumInfo en, String ws) throws Exception {
+        // old:
         StringBuffer buf = new StringBuffer();
+        
+        // new:
+        //buf.append(ws + "print('DEBUG: test -- we got here!!! (SeriesObject unpackFromDict())')\n");
+        // old:
         buf.append(ws + extends_name(infos, info, outfile, st, en, "") + ".unpackFromDict(self, d, seriesFactory)\n" );
         if (st.fields.length > 0) {
             buf.append(ws + "for key in d:\n");
         }
+        
         boolean first = true;
         for (FieldInfo f : st.fields) {
             String name = "self." + f.name;

--- a/src/templates/py/LMCPFactory.py
+++ b/src/templates/py/LMCPFactory.py
@@ -86,6 +86,18 @@ class LMCPFactory:
         if type(d) is not dict:
             return None
 
+        # new:
+        #print("DEBUG: went inside 'unpackFromDict' function in LmcpFactory -- loc -1")
+        #print("DEBUG: d = '%r'%")
+        if ("datatype" in d.keys() and "datastring" in d.keys()): # if we needed to do the 'datatype' 'datastring' thing in toDict...
+            #print("DEBUG: went inside 'if' statement -- loc -2")
+            hold = d
+            hold2 = {}
+            import ast
+            hold2[str(d['datatype'])] = ast.literal_eval(str(d['datastring'])) # then unpack it and "overwrite" d so all the other stuff works out just fine again :)
+            d = hold2
+        # original continues:
+        
         obj = None
         for key in d:
             if type(d[key]) is dict:

--- a/src/templates/py/SeriesObject.py
+++ b/src/templates/py/SeriesObject.py
@@ -64,7 +64,17 @@ class -<classname>-(-<extends_name>-):
         m = {}
         self.toDictMembers(m)
         d = {}
-        d[-<series_name>- + "/-<datatype_name>-"] = m
+        # original:
+        #d[-<series_name>- + "/-<datatype_name>-"] = m
+        # new:
+        if (-<series_name>- is None) or (-<series_name>- is ""): # it should never do this!
+            # need to fill this with something...
+            d["datatype"] = str("DEBUG_PROBLEM_HERE" + "/-<datatype_name>-")
+            d["datastring"] = str(m)
+        else:
+            d['datatype'] = str(-<series_name>- + "/-<datatype_name>-")
+            d['datastring'] = str(m)
+        # original:
         return d
 
     def toDictMembers(self, d):


### PR DESCRIPTION
…the JSOn messages so that (potentially) dynamic parts of the messages won't cause ROS to balk (splitting key typename value-data parts into key 'datatype' value typename and key datastring' value data -- strings -- to send through roscore via rosbridge)