### PR TITLE
Allow MDM structs to explicity specify their type ids

### DIFF
--- a/src/avtas/lmcp/lmcpgen/MDM.DTD
+++ b/src/avtas/lmcp/lmcpgen/MDM.DTD
@@ -43,6 +43,7 @@
     Extends CDATA ''
     Name CDATA #REQUIRED
     Series CDATA ''
+    ID CDATA ''
   >
 
 <!--- Enumeration definition -->

--- a/src/avtas/lmcp/lmcpgen/MDMReader.java
+++ b/src/avtas/lmcp/lmcpgen/MDMReader.java
@@ -106,9 +106,21 @@ public class MDMReader {
         }
 
         info.structs = fillStructs(XMLUtil.getList(node, "StructList", "Struct"), info);
+
+        // Determine start ID by looking for the maximum specified ID (0 by default)
         for (int i = 0; i < info.structs.length; i++) {
-            info.structs[i].id = startId + i;
+            startId = Math.max(startId, info.structs[i].id + 1);
         }
+
+        // Assign IDs for structs that do not yet have one
+        int idOffset = 0;
+        for (int i = 0; i < info.structs.length; i++) {
+            if (info.structs[i].id < 1) {
+                info.structs[i].id = startId + idOffset;
+                idOffset++;
+            }
+        }
+
         info.enums = fillEnums(XMLUtil.getList(node, "EnumList", "Enum"), info);
 
         return info;
@@ -150,6 +162,12 @@ public class MDMReader {
             struct.comment = XMLUtil.get(list[i], "Comment", "").replaceAll("[\n\r\f]+", "");
             if (struct.comment.isEmpty()) {
                 struct.comment = getComment(list[i]).replaceAll("[\n\r\f]+", "");
+            }
+
+            // Optional explicit ID
+            String idStr = XMLUtil.getAttribute(list[i], "ID", "");
+            if (!idStr.isEmpty()) {
+                struct.id = Integer.parseInt(idStr);
             }
 
 


### PR DESCRIPTION
Added an ID attribute to the Struct tag in the MDM XML. If this attribute is specified, the struct will be assigned that integer id (as opposed to it being based on the XML ordering of the Struct tags).

Structs that do not have explicit ID attributes are assigned ids starting from one past the maximum explicit ID, or zero if none are given. This produces the original id assignment behavior if no explicit Struct ID attributes exist (the first struct has id 1, the second 2, etc.). If any struct has ID="N" (where N is the maximum value in the MDM), then all structs without an ID will start at N+1, increasing with their order in the XML.