### PR TITLE
Python 3 compatibility

### DIFF
--- a/src/avtas/lmcp/lmcpgen/PythonMethods.java
+++ b/src/avtas/lmcp/lmcpgen/PythonMethods.java
@@ -238,7 +238,7 @@ class PythonMethods {
                 if (f.type.equalsIgnoreCase("string")) {
                     buf.append(ws + "buffer.append(struct.pack(\">H\", len(" + name + ") ))\n");
                     buf.append(ws + "if len(" + name + ") > 0:\n");
-                    buf.append(ws + "    buffer.append(struct.pack( `len(" + name + ")` + \"s\", str(" + name + ")))\n");
+                    buf.append(ws + "    buffer.append(struct.pack( repr(len(" + name + ")) + \"s\", str(" + name + ")))\n");
                 } else if (f.type.equalsIgnoreCase("Bool")) {
                     buf.append(ws + "boolChar = 1 if " + name + " == True else 0\n");
                     buf.append(ws + "buffer.append(struct.pack(\">B\",boolChar))\n");
@@ -274,7 +274,7 @@ class PythonMethods {
                     buf.append(ws + "for x in " + name + ":\n");
                     buf.append(ws + "    buffer.append(struct.pack(\">H\", len(x) ))\n");
                     buf.append(ws + "    if len(x) > 0:\n");
-                    buf.append(ws + "        buffer.append(struct.pack( `len(x)` + \"s\", str(" + name + "[x])))\n");
+                    buf.append(ws + "        buffer.append(struct.pack( repr(len(x)) + \"s\", str(" + name + "[x])))\n");
                 } else if (f.type.equalsIgnoreCase("Bool")) {
                     buf.append(ws + "for x in " + name + ":\n");
                     buf.append(ws + "    boolChar = 1 if x == True else 0\n");
@@ -299,7 +299,7 @@ class PythonMethods {
                     buf.append(ws + "_strlen = struct.unpack_from(\">H\", buffer, _pos )[0]\n");
                     buf.append(ws + "_pos += 2\n");
                     buf.append(ws + "if _strlen > 0:\n");
-                    buf.append(ws + "    " + name + " = struct.unpack_from( `_strlen` + \"s\", buffer, _pos )[0]\n");
+                    buf.append(ws + "    " + name + " = struct.unpack_from( repr(_strlen) + \"s\", buffer, _pos )[0]\n");
                     buf.append(ws + "    _pos += _strlen\n");
                     buf.append(ws + "else:\n ");
                     buf.append(ws + "    " + name + " = \"\"\n");
@@ -363,7 +363,7 @@ class PythonMethods {
                     buf.append(ws + "    _strlen = struct.unpack_from(\">H\", buffer, _pos )[0]\n");
                     buf.append(ws + "    _pos += 2\n");
                     buf.append(ws + "    if _strlen > 0:\n");
-                    buf.append(ws + "        " + name + "[x] = struct.unpack_from( `_strlen` + \"s\", buffer, _pos )[0]\n");
+                    buf.append(ws + "        " + name + "[x] = struct.unpack_from( repr(_strlen) + \"s\", buffer, _pos )[0]\n");
                     buf.append(ws + "        _pos += _strlen\n");
                     buf.append(ws + "    else:\n ");
                     buf.append(ws + "        " + name + "[x] = \"\"\n");
@@ -373,7 +373,7 @@ class PythonMethods {
                     buf.append(ws + "    " + name + "[x] = True if boolChar == 1 else False\n");
                     buf.append(ws + "    _pos += 1\n");
                 } else {
-                    String typeStr = "\">\" + `_arraylen` + \"" + getStructTypeString(f) + "\"";
+                    String typeStr = "\">\" + repr(_arraylen) + \"" + getStructTypeString(f) + "\"";
                     buf.append(ws + "if _arraylen > 0:\n");
                     buf.append(ws + "    " + name + " = struct.unpack_from(" + typeStr + ", buffer, _pos )\n");
                     buf.append(ws + "    _pos += " + sizeOf(f) + " * _arraylen\n");
@@ -459,7 +459,7 @@ class PythonMethods {
         for(MDMInfo in : infos){
             if(in.seriesName.equals(info.seriesName)){
                 for(StructInfo si : in.structs){
-                    buf.append(ws + "import " + si.name + "\n");
+                    buf.append(ws + "from . import " + si.name + "\n");
                 }
             }
         }

--- a/src/avtas/lmcp/lmcpgen/PythonMethods.java
+++ b/src/avtas/lmcp/lmcpgen/PythonMethods.java
@@ -433,7 +433,7 @@ class PythonMethods {
     public static String list_name_for_type(MDMInfo[] infos, MDMInfo info, File outfile, StructInfo st, EnumInfo en, String ws) throws Exception {
         StringBuffer buf = new StringBuffer();
         for (int i = 0; i < info.structs.length; i++) {
-            buf.append( ws + "if(type ==  " + info.structs[i].id + "): return \"" + info.structs[i].name + "\"\n" );
+            buf.append( ws + "if(type_ ==  " + info.structs[i].id + "): return \"" + info.structs[i].name + "\"\n" );
         }
         return buf.toString();
     }
@@ -449,7 +449,7 @@ class PythonMethods {
     public static String list_instance_for_type(MDMInfo[] infos, MDMInfo info, File outfile, StructInfo st, EnumInfo en, String ws) throws Exception {
         StringBuffer buf = new StringBuffer();
         for (int i = 0; i < info.structs.length; i++) {
-            buf.append( ws + "if(type ==  " + info.structs[i].id + "): return " + info.structs[i].name + "." + info.structs[i].name + "()\n" );
+            buf.append( ws + "if(type_ ==  " + info.structs[i].id + "): return " + info.structs[i].name + "." + info.structs[i].name + "()\n" );
         }
         return buf.toString();
     }

--- a/src/templates/py/LMCPClient.py
+++ b/src/templates/py/LMCPClient.py
@@ -22,6 +22,6 @@ buf = []
 
 -<pack_all_messages>-
 
-s.send("".join(buf))
+s.send(b"".join(buf))
 
 

--- a/src/templates/py/LMCPFactory.py
+++ b/src/templates/py/LMCPFactory.py
@@ -149,17 +149,17 @@ def packMessage(lmcpObject, calcChecksum):
     obj_buffer.append(struct.pack(">I", lmcpObject.LMCP_TYPE))
     obj_buffer.append(struct.pack(">H", lmcpObject.SERIES_VERSION))
     obj_buffer.append(obj_tmp)
-    hdr_buffer.append(struct.pack(">I", len("".join(obj_buffer))))
+    hdr_buffer.append(struct.pack(">I", len(b"".join(obj_buffer))))
     total_buffer.extend(hdr_buffer)
     total_buffer.extend(obj_buffer)
 
     #pack the checksum
     if calcChecksum:
-        total_buffer.append(struct.pack(">I", calculateChecksum("".join(total_buffer), 0)))
+        total_buffer.append(struct.pack(">I", calculateChecksum(b"".join(total_buffer), 0)))
     else:
         total_buffer.append(struct.pack(">I", 0))
 
-    return "".join(total_buffer)
+    return b"".join(total_buffer)
 
 def getSize(buffer):
     return struct.unpack_from(">I", buffer, 4)[0]

--- a/src/templates/py/LMCPFactory.py
+++ b/src/templates/py/LMCPFactory.py
@@ -35,10 +35,10 @@ class LMCPFactory:
         if len(buffer) < HEADER_SIZE:
             print("getObject() : buffer too small for message")
             return None
-        type = getLMCPType(buffer)
+        type_ = getLMCPType(buffer)
         series = getLMCPSeries(buffer)
         version = getLMCPVersion(buffer)
-        obj = self.createObject(series, version, type)
+        obj = self.createObject(series, version, type_)
         if obj != None:
            obj.unpack(buffer, HEADER_SIZE + 15)
         return obj

--- a/src/templates/py/LMCPFactory.py
+++ b/src/templates/py/LMCPFactory.py
@@ -33,7 +33,7 @@ class LMCPFactory:
 
     def getObject(self, buffer):
         if len(buffer) < HEADER_SIZE:
-            print  "getObject() : buffer too small for message"
+            print("getObject() : buffer too small for message")
             return None
         type = getLMCPType(buffer)
         series = getLMCPSeries(buffer)
@@ -51,7 +51,7 @@ class LMCPFactory:
         msgSize = getSize(header)
         msgBody = fileobj.read(msgSize + CHECKSUM_SIZE)
         if  validate(header + msgBody) != True:
-            print "LMCPFactory : bad checksum. "
+            print("LMCPFactory : bad checksum. ")
             return None
         return self.getObject(header + msgBody)
 

--- a/src/templates/py/LMCPFactory.py
+++ b/src/templates/py/LMCPFactory.py
@@ -83,7 +83,7 @@ class LMCPFactory:
         return objs
 
     def unpackFromDict(self, d):
-        if type(d) is not dict:
+        if not isinstance(d, dict):
             return None
 
         if ("datatype" in d.keys() and "datastring" in d.keys()):
@@ -94,7 +94,7 @@ class LMCPFactory:
         
         obj = None
         for key in d:
-            if type(d[key]) is dict:
+            if isinstance(d[key], dict):
                 name_parts = key.split("/")
                 if len(name_parts) == 2:
                    series_name = name_parts[0]

--- a/src/templates/py/LMCPFactory.py
+++ b/src/templates/py/LMCPFactory.py
@@ -1,5 +1,5 @@
 import struct
-import LMCPObject;
+from . import LMCPObject;
 import xml.dom.minidom
 
 ## ===============================================================================

--- a/src/templates/py/LMCPServer.py
+++ b/src/templates/py/LMCPServer.py
@@ -26,7 +26,7 @@ class LMCPHandler(SocketServer.StreamRequestHandler):
                 size = LMCPFactory.getSize(data[0])
                 print "object size: %d" % (size,)
                 data.append(self.request.recv(size+4)) # compensate for checksum
-                data_str = "".join(data)
+                data_str = b"".join(data)
                 print "%d bytes received" % (len(data_str),)
                 recv_obj = self.factory.getObject(data_str)
                 print "%s received" % recv_obj.__class__

--- a/src/templates/py/SeriesEnum.py
+++ b/src/templates/py/SeriesEnum.py
@@ -17,13 +17,13 @@ from lmcp.LMCPObject import *
 
 class SeriesEnum:
 
-    def getName(self, type):
+    def getName(self, type_):
         -<list_name_for_type>-
 
     def getType(self, name):
         -<list_type_for_name>-
         return -1
 
-    def getInstance(self, type):
+    def getInstance(self, type_):
         -<list_instance_for_type>-
         return None

--- a/src/templates/py/SeriesObject.py
+++ b/src/templates/py/SeriesObject.py
@@ -35,7 +35,7 @@ class -<classname>-(-<extends_name>-):
         """
         buffer = []
         -<pack_vars>-
-        return "".join(buffer)
+        return b"".join(buffer)
 
     def unpack(self, buffer, _pos):
         """


### PR DESCRIPTION
Differences between Python 2/3:
- Py2 `str` is a `byte`s-like object, whereas in Py3 it is a `unicode`. Explicitly telling Python to use `bytes` does not break backwards compatibility with Py2.
- Py2 allows relative imports in a more lax manner than does Py3. Fixed with explicit reference.
- Py2 `print` statement replaced with Py3 `print()` function (this was mostly fixed already, but there 
were a few stragglers).

Other general Python fixes
- `type` is a built-in function which was being overridden by function local. Changed according to [PEP 8](http://legacy.python.org/dev/peps/pep-0008/#descriptive-naming-styles)
- Explicit type comparison using `type()` is discouraged. Changed to use `isinstance()` for better dependability in accordance with [PEP 8](http://legacy.python.org/dev/peps/pep-0008/#programming-recommendations)