### PR TITLE
adding cs null check for optional structs.

### DIFF
--- a/src/avtas/lmcp/lmcpgen/CsMethods.java
+++ b/src/avtas/lmcp/lmcpgen/CsMethods.java
@@ -878,7 +878,11 @@ class CsMethods {
                 code += String.format("%1$s}\n\n", ws, name);
             }
             else{
-                code += String.format("%1$sif (!%2$s.Equals(other.%2$s)) return false;\n\n", ws, name);
+                code += String.format("%1$sif (", ws);
+                if (f.isStruct && f.isOptional) {
+                    code += String.format("%1$s != null && ", name);
+                }
+                code += String.format("!%1$s.Equals(other.%1$s)) return false;\n\n", name);
             }
         }
 


### PR DESCRIPTION
This fixes a null reference exception in C# when using the equals method and both objects have an optional property set to null. 

Example change in output for  the AngledAreaSearchTask.cs file in the IMPACT MDM:

before:
  // StartPoint
  if ((StartPoint == null && other.StartPoint != null) || (other.StartPoint == null && StartPoint != null)) return false;
  if (!StartPoint.Equals(other.StartPoint)) return false;

after:
  // StartPoint
  if ((StartPoint == null && other.StartPoint != null) || (other.StartPoint == null && StartPoint != null)) return false;
  if (StartPoint != null && !StartPoint.Equals(other.StartPoint)) return false;