### PR TITLE
Net standard update

### DIFF
--- a/src/avtas/lmcp/lmcpgen/CsMethods.java
+++ b/src/avtas/lmcp/lmcpgen/CsMethods.java
@@ -900,43 +900,7 @@ class CsMethods {
         }
         return buf.toString();
     }
-
-    public static String project_sources(MDMInfo[] infos, MDMInfo info, File outfile, StructInfo st, EnumInfo en, String ws) throws Exception {
-        String str = "";
-        for (MDMInfo i : infos) {
-            if(i.seriesNameAsLong == 0)
-            {
-                continue;
-            }
-            String winDir = getCsNamespace(i.namespace).replaceAll("\\.", "\\\\");
-            for (StructInfo s : i.structs ) {
-                str += ws + "<Compile Include=\"" + winDir + "\\" + s.name + ".cs\"/>\n";
-            }
-            for (EnumInfo s : i.enums ) {
-                str += ws + "<Compile Include=\"" + winDir + "\\" + s.name + ".cs\"/>\n";
-            }
-            str += ws + "<Compile Include=\"" + winDir + "\\"  + "SeriesEnum.cs\"/>\n";
-            str += ws + "<Compile Include=\"" + winDir + "\\"  + "SeriesList.cs\"/>\n";
-            str += ws + "<Compile Include=\"" + winDir + "\\"  + "SeriesXmlReader.cs\"/>\n";
-        }
-        return str;
-    }
     
-    public static String series_csproj_sources(MDMInfo[] infos, MDMInfo info, File outfile, StructInfo st, EnumInfo en, String ws) throws Exception {
-        String str = "";
-        String winDir = getCsNamespace(info.namespace).replaceAll("\\.", "\\\\");
-        for (StructInfo s : info.structs ) {
-            str += ws + "<Compile Include=\"" + winDir + "\\" + s.name + ".cs\"/>\n";
-        }
-        for (EnumInfo s : info.enums ) {
-            str += ws + "<Compile Include=\"" + winDir + "\\" + s.name + ".cs\"/>\n";
-        }
-        str += ws + "<Compile Include=\"" + winDir + "\\"  + "SeriesEnum.cs\"/>\n";
-        str += ws + "<Compile Include=\"" + winDir + "\\"  + "SeriesList.cs\"/>\n";
-        str += ws + "<Compile Include=\"" + winDir + "\\"  + "SeriesXmlReader.cs\"/>\n";
-        return str;
-    }
-
     public static String series_csproj_references(MDMInfo[] infos, MDMInfo info, File outfile, StructInfo st, EnumInfo en, String ws) throws Exception {
         
         String str = "";
@@ -945,10 +909,7 @@ class CsMethods {
                 if (i.seriesName.contentEquals(dep))
                 {
                     String libName = dep.substring(0, 1).toUpperCase() + dep.substring(1).toLowerCase();
-                    str += ws + "<ProjectReference Include=\"Lmcp" + libName + ".csproj\">\n";
-                    str += ws + "  <Project>{" + i.guid + "}</Project>\n";
-                    str += ws + "  <Name>Lmcp" + libName + "</Name>\n";
-                    str += ws + "</ProjectReference>\n";
+                    str += ws + "<ProjectReference Include=\"..\\" + libName + "\\Lmcp" + libName + ".csproj\" />\n";
                 }
             }
         }
@@ -960,10 +921,7 @@ class CsMethods {
         for (MDMInfo i : infos) {
             if (i.seriesNameAsLong == 0) { continue; }
             String libName = i.seriesName.substring(0, 1).toUpperCase() + i.seriesName.substring(1).toLowerCase();
-            str += ws + "<ProjectReference Include=\"Lmcp" + libName + ".csproj\">\n";
-            str += ws + "  <Project>{" + i.guid + "}</Project>\n";
-            str += ws + "  <Name>Lmcp" + libName + "</Name>\n";
-            str += ws + "</ProjectReference>\n";
+            str += ws + "<ProjectReference Include=\"..\\Library\\" + libName + "\\Lmcp" + libName + ".csproj\" />\n";
         }
         return str;
     }
@@ -994,7 +952,7 @@ class CsMethods {
         String str = "";
         for(MDMInfo i : infos) {
             String libName = i.seriesName.substring(0, 1).toUpperCase() + i.seriesName.substring(1).toLowerCase();
-            str += ws + "Project(\"{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}\") = \"Lmcp" + libName + "\", \"Library\\Lmcp" + libName + ".csproj\", \"{" + i.guid + "}\"\n";
+            str += ws + "Project(\"{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}\") = \"Lmcp" + libName + "\", \"Library\\" + libName + "\\Lmcp" + libName + ".csproj\", \"{" + i.guid + "}\"\n";
             str += ws + "EndProject\n";
         }
         return str;

--- a/src/avtas/lmcp/lmcpgen/CsMethods.java
+++ b/src/avtas/lmcp/lmcpgen/CsMethods.java
@@ -928,6 +928,7 @@ class CsMethods {
 	
 	public static String get_nuget_mdm_dependencies(MDMInfo[] infos, MDMInfo info, File outfile, StructInfo st, EnumInfo en, String ws) throws Exception {
         String str = "    <dependencies>\n";
+        str += "      <dependency id=\"Lmcp.Core\" version=\"[1,2)\"/>\n";
         if ( infos.length == 0 )
             return str + "    </dependencies>\n";
         

--- a/src/templates/cs.tl
+++ b/src/templates/cs.tl
@@ -17,6 +17,7 @@ ONCE            cs/LmcpCoreXmlReader.cs             Library/LmcpCore/Avtas/Lmcp/
 ONCE            cs/LmcpCoreXmlReader.cs             Library/LmcpCore/Avtas/Lmcp/LmcpXmlReader.cs
 ONCE            cs/LmcpXmlWriter.cs                 Library/LmcpCore/Avtas/Lmcp/LmcpXmlWriter.cs
 ONCE            cs/ISeriesList.cs                   Library/LmcpCore/Avtas/Lmcp/ISeriesList.cs
+ONCE            cs/LmcpCore.nuspec                  Library/LmcpCore/LmcpCore.nuspec
 ONCE            cs/CreateNugetPackages.bat          Library/CreateNugetPackages.bat
 
 ONCE            cs/TestClient.csproj                TestClient/TestClient.csproj

--- a/src/templates/cs.tl
+++ b/src/templates/cs.tl
@@ -2,21 +2,21 @@
 
 ONCE            cs/LMCP.sln                         ./LMCP.sln
 
-ONCE            cs/LMCP.csproj                      Library/LMCP.csproj
-ONCE            cs/LmcpCore.csproj                  Library/LmcpCore.csproj
-ONCE            cs/LibraryAssemblyInfo.cs           Library/Properties/AssemblyInfo.cs
-ONCE            cs/ILmcpObject.cs                   Library/Avtas/Lmcp/ILmcpObject.cs
-ONCE            cs/LmcpFactory.cs                   Library/Avtas/Lmcp/LmcpFactory.cs
-ONCE            cs/LmcpCoreFactory.cs               Library/Avtas/Lmcp/LmcpCoreFactory.cs
-ONCE            cs/LmcpFactoryException.cs          Library/Avtas/Lmcp/LmcpFactoryException.cs
-ONCE            cs/LmcpBinaryReader.cs              Library/Avtas/Lmcp/LmcpBinaryReader.cs
-ONCE            cs/LmcpBinaryWriter.cs              Library/Avtas/Lmcp/LmcpBinaryWriter.cs
-ONCE            cs/LmcpBinaryProcessor.cs           Library/Avtas/Lmcp/LmcpBinaryProcessor.cs
-ONCE            cs/LmcpObjectReceivedEventArgs.cs   Library/Avtas/Lmcp/LmcpObjectReceivedEventArgs.cs
-ONCE            cs/LmcpXmlReader.cs                 Library/Avtas/Lmcp/LmcpXmlReader.cs
-ONCE            cs/LmcpCoreXmlReader.cs             Library/Avtas/Lmcp/LmcpCoreXmlReader.cs
-ONCE            cs/LmcpXmlWriter.cs                 Library/Avtas/Lmcp/LmcpXmlWriter.cs
-ONCE            cs/ISeriesList.cs                   Library/Avtas/Lmcp/ISeriesList.cs
+ONCE            cs/LmcpCore.csproj                  Library/LMCP.csproj
+ONCE            cs/LmcpCore.csproj                  Library/LmcpCore/LmcpCore.csproj
+ONCE            cs/LibraryAssemblyInfo.cs           Library/LmcpCore/Properties/AssemblyInfo.cs
+ONCE            cs/ILmcpObject.cs                   Library/LmcpCore/Avtas/Lmcp/ILmcpObject.cs
+ONCE            cs/LmcpCoreFactory.cs               Library/LmcpCore/Avtas/Lmcp/LmcpCoreFactory.cs
+ONCE            cs/LmcpCoreFactory.cs               Library/LmcpCore/Avtas/Lmcp/LmcpFactory.cs
+ONCE            cs/LmcpFactoryException.cs          Library/LmcpCore/Avtas/Lmcp/LmcpFactoryException.cs
+ONCE            cs/LmcpBinaryReader.cs              Library/LmcpCore/Avtas/Lmcp/LmcpBinaryReader.cs
+ONCE            cs/LmcpBinaryWriter.cs              Library/LmcpCore/Avtas/Lmcp/LmcpBinaryWriter.cs
+ONCE            cs/LmcpBinaryProcessor.cs           Library/LmcpCore/Avtas/Lmcp/LmcpBinaryProcessor.cs
+ONCE            cs/LmcpObjectReceivedEventArgs.cs   Library/LmcpCore/Avtas/Lmcp/LmcpObjectReceivedEventArgs.cs
+ONCE            cs/LmcpCoreXmlReader.cs             Library/LmcpCore/Avtas/Lmcp/LmcpCoreXmlReader.cs
+ONCE            cs/LmcpCoreXmlReader.cs             Library/LmcpCore/Avtas/Lmcp/LmcpXmlReader.cs
+ONCE            cs/LmcpXmlWriter.cs                 Library/LmcpCore/Avtas/Lmcp/LmcpXmlWriter.cs
+ONCE            cs/ISeriesList.cs                   Library/LmcpCore/Avtas/Lmcp/ISeriesList.cs
 ONCE            cs/CreateNugetPackages.bat          Library/CreateNugetPackages.bat
 
 ONCE            cs/TestClient.csproj                TestClient/TestClient.csproj
@@ -26,12 +26,12 @@ ONCE            cs/TestServer.csproj                TestServer/TestServer.csproj
 ONCE            cs/TestServer.cs                    TestServer/Program.cs
 ONCE            cs/TestServerAssemblyInfo.cs        TestServer/Properties/AssemblyInfo.cs
 
-PER_MDM         cs/SeriesList.cs                    Library/-<namespace>-/SeriesList.cs
-PER_MDM         cs/SeriesEnum.cs                    Library/-<namespace>-/SeriesEnum.cs
-PER_MDM         cs/SeriesXmlReader.cs               Library/-<namespace>-/SeriesXmlReader.cs
-PER_MDM         cs/SeriesProj.csproj                Library/Lmcp-<cs_series_name>-.csproj
-PER_MDM         cs/SeriesNuget.nuspec               Library/-<cs_series_name>-.nuspec
+PER_MDM         cs/SeriesList.cs                    Library/-<cs_series_name>-/-<namespace>-/SeriesList.cs
+PER_MDM         cs/SeriesEnum.cs                    Library/-<cs_series_name>-/-<namespace>-/SeriesEnum.cs
+PER_MDM         cs/SeriesXmlReader.cs               Library/-<cs_series_name>-/-<namespace>-/SeriesXmlReader.cs
+PER_MDM         cs/SeriesProj.csproj                Library/-<cs_series_name>-/Lmcp-<cs_series_name>-.csproj
+PER_MDM         cs/SeriesNuget.nuspec               Library/-<cs_series_name>-/-<cs_series_name>-.nuspec
 
-PER_STRUCT      cs/SeriesObject.cs                  Library/-<namespace>-/-<datatype_name>-.cs
+PER_STRUCT      cs/SeriesObject.cs                  Library/-<cs_series_name>-/-<namespace>-/-<datatype_name>-.cs
 
-PER_ENUM        cs/Enum.cs                          Library/-<namespace>-/-<enum_name>-.cs
+PER_ENUM        cs/Enum.cs                          Library/-<cs_series_name>-/-<namespace>-/-<enum_name>-.cs

--- a/src/templates/cs/CreateNugetPackages.bat
+++ b/src/templates/cs/CreateNugetPackages.bat
@@ -1,3 +1,3 @@
 : This script creates .nupkg files for each .nuspec. Ensure that nuget.exe (v3.5 or newer) 
 : is either in the PATH or place it in this folder.
-for %%i in (*.nuspec) do nuget pack %%i
+for /R %%i in (*.nuspec) do nuget pack %%i -OutputDirectory %%~ni

--- a/src/templates/cs/LMCP.csproj
+++ b/src/templates/cs/LMCP.csproj
@@ -1,77 +1,19 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>9.0.30729</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{-<library_make_guid>-}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Afrl</RootNamespace>
-    <AssemblyName>LMCP</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
+    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <DocumentationFile>bin\Debug\LMCP.XML</DocumentationFile>
-    <NoWarn>1591</NoWarn>
+  
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DocumentationFile>bin\Release\netstandard2.0\Lmcp.xml</DocumentationFile>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <DocumentationFile>bin\Release\LMCP.XML</DocumentationFile>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>1591</NoWarn>
+  
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DocumentationFile>bin\Debug\netstandard2.0\Lmcp.xml</DocumentationFile>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Xml.Linq">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Data.DataSetExtensions">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>    
-    <Compile Include="Avtas\Lmcp\ILmcpObject.cs" />
-    <Compile Include="Avtas\Lmcp\LmcpBinaryProcessor.cs" />
-    <Compile Include="Avtas\Lmcp\LmcpBinaryReader.cs" />
-    <Compile Include="Avtas\Lmcp\LmcpBinaryWriter.cs" />
-    <Compile Include="Avtas\Lmcp\LmcpCoreFactory.cs" />
-    <Compile Include="Avtas\Lmcp\LmcpFactory.cs" />
-    <Compile Include="Avtas\Lmcp\LmcpFactoryException.cs" />
-    <Compile Include="Avtas\Lmcp\LmcpObjectReceivedEventArgs.cs" />
-    <Compile Include="Avtas\Lmcp\LmcpXmlReader.cs" />
-    <Compile Include="Avtas\Lmcp\LmcpCoreXmlReader.cs" />
-    <Compile Include="Avtas\Lmcp\LmcpXmlWriter.cs" />
-    <Compile Include="Avtas\Lmcp\ISeriesList.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    -<project_sources>-
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/src/templates/cs/LMCP.sln
+++ b/src/templates/cs/LMCP.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LmcpCore", "Library\LmcpCore.csproj", "{-<core_library_make_guid>-}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LmcpCore", "Library\LmcpCore\LmcpCore.csproj", "{-<core_library_make_guid>-}"
 EndProject
 -<all_series_projects>-
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestClient", "TestClient\TestClient.csproj", "{-<test_client_make_guid>-}"

--- a/src/templates/cs/LmcpBinaryWriter.cs
+++ b/src/templates/cs/LmcpBinaryWriter.cs
@@ -312,7 +312,7 @@ namespace Avtas.Lmcp
         Write(true);
         Write(obj.SeriesNameAsLong);
         Write(obj.LmcpType);
-        Write(obj.Version);
+        Write(obj.SeriesVersion);
         obj.Pack(this.BaseStream);
       }
     }

--- a/src/templates/cs/LmcpCore.csproj
+++ b/src/templates/cs/LmcpCore.csproj
@@ -1,74 +1,23 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>9.0.30729</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{-<core_library_make_guid>-}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Afrl</RootNamespace>
-    <AssemblyName>LmcpCore</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
+    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <DocumentationFile>bin\Debug\LmcpCore.XML</DocumentationFile>
-    <NoWarn>1591</NoWarn>
+  
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DocumentationFile>bin\Release\netstandard2.0\LmcpCore.xml</DocumentationFile>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <DocumentationFile>bin\Release\LmcpCore.XML</DocumentationFile>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>1591</NoWarn>
+  
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DocumentationFile>bin\Debug\netstandard2.0\LmcpCore.xml</DocumentationFile>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Xml.Linq">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Data.DataSetExtensions">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>    
-    <Compile Include="Avtas\Lmcp\ILmcpObject.cs" />
-    <Compile Include="Avtas\Lmcp\LmcpBinaryProcessor.cs" />
-    <Compile Include="Avtas\Lmcp\LmcpBinaryReader.cs" />
-    <Compile Include="Avtas\Lmcp\LmcpBinaryWriter.cs" />
-    <Compile Include="Avtas\Lmcp\LmcpCoreFactory.cs" />
-    <Compile Include="Avtas\Lmcp\LmcpFactoryException.cs" />
-    <Compile Include="Avtas\Lmcp\LmcpObjectReceivedEventArgs.cs" />
-    <Compile Include="Avtas\Lmcp\LmcpCoreXmlReader.cs" />
-    <Compile Include="Avtas\Lmcp\LmcpXmlWriter.cs" />
-    <Compile Include="Avtas\Lmcp\ISeriesList.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+
+  <PropertyGroup>
+    <DefaultItemExcludes>$(DefaultItemExcludes);**\LmcpFactory.cs;**\LmcpXmlReader.cs</DefaultItemExcludes>
+  </PropertyGroup>
 </Project>

--- a/src/templates/cs/LmcpCore.nuspec
+++ b/src/templates/cs/LmcpCore.nuspec
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>Lmcp.Core</id>
+    <version>1</version>
+    <title>Lmcp.Core Lmcp Library</title>
+    <authors>AFRL</authors>
+    <owners>AFRL</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Lmcp messaging library and deserialization/serialization for Lmcp.Core</description>
+    <copyright>Copyright 2018</copyright>
+    <tags>lmcp Lmcp.Core messaging message messages</tags>
+    <dependencies />
+  </metadata>
+  <files>
+    <file src="Bin\Release\netstandard2.0\LmcpCore.dll" target="lib\net452"/>
+    <file src="Bin\Release\netstandard2.0\LmcpCore.xml" target="lib\net452"/>
+  </files>
+</package>

--- a/src/templates/cs/LmcpCore.nuspec
+++ b/src/templates/cs/LmcpCore.nuspec
@@ -13,7 +13,7 @@
     <dependencies />
   </metadata>
   <files>
-    <file src="Bin\Release\netstandard2.0\LmcpCore.dll" target="lib\net452"/>
-    <file src="Bin\Release\netstandard2.0\LmcpCore.xml" target="lib\net452"/>
+    <file src="Bin\Release\netstandard2.0\LmcpCore.dll" target="lib\netstandard2.0"/>
+    <file src="Bin\Release\netstandard2.0\LmcpCore.xml" target="lib\netstandard2.0"/>
   </files>
 </package>

--- a/src/templates/cs/SeriesNuget.nuspec
+++ b/src/templates/cs/SeriesNuget.nuspec
@@ -13,8 +13,8 @@
     -<get_nuget_mdm_dependencies>-
   </metadata>
   <files>
-    <file src="Bin\Release\Lmcp-<cs_series_name>-.dll" target="lib\net452"/>
-    <file src="Bin\Release\Lmcp-<cs_series_name>-.xml" target="lib\net452"/>
-    <file src="..\-<series_name>-.xml" target="tools"/>
+    <file src="Bin\Release\netstandard2.0\Lmcp-<cs_series_name>-.dll" target="lib\net452"/>
+    <file src="Bin\Release\netstandard2.0\Lmcp-<cs_series_name>-.xml" target="lib\net452"/>
+    <file src="..\..\-<series_name>-.xml" target="tools"/>
   </files>
 </package>

--- a/src/templates/cs/SeriesNuget.nuspec
+++ b/src/templates/cs/SeriesNuget.nuspec
@@ -13,8 +13,8 @@
     -<get_nuget_mdm_dependencies>-
   </metadata>
   <files>
-    <file src="Bin\Release\netstandard2.0\Lmcp-<cs_series_name>-.dll" target="lib\net452"/>
-    <file src="Bin\Release\netstandard2.0\Lmcp-<cs_series_name>-.xml" target="lib\net452"/>
+    <file src="Bin\Release\netstandard2.0\Lmcp-<cs_series_name>-.dll" target="lib\netstandard2.0"/>
+    <file src="Bin\Release\netstandard2.0\Lmcp-<cs_series_name>-.xml" target="lib\netstandard2.0"/>
     <file src="..\..\-<series_name>-.xml" target="tools"/>
   </files>
 </package>

--- a/src/templates/cs/SeriesProj.csproj
+++ b/src/templates/cs/SeriesProj.csproj
@@ -1,71 +1,18 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>9.0.30729</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{-<series_guid>-}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>-<direct_series_namespace>-</RootNamespace>
-    <AssemblyName>Lmcp-<cs_series_name>-</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <DocumentationFile>bin\Debug\Lmcp-<cs_series_name>-.XML</DocumentationFile>
-    <NoWarn>1591</NoWarn>
+  
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DocumentationFile>bin\Release\netstandard2.0\Lmcp-<cs_series_name>-.xml</DocumentationFile>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <DocumentationFile>bin\Release\Lmcp-<cs_series_name>-.XML</DocumentationFile>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>1591</NoWarn>
+  
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DocumentationFile>bin\Debug\netstandard2.0\Lmcp-<cs_series_name>-.xml</DocumentationFile>
   </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Xml.Linq">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Data.DataSetExtensions">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    -<series_csproj_sources>-
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="LmcpCore.csproj">
-      <Project>{-<core_library_make_guid>-}</Project>
-      <Name>LmcpCore</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\LmcpCore\LmcpCore.csproj" />
     -<series_csproj_references>-
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/src/templates/cs/TestClient.csproj
+++ b/src/templates/cs/TestClient.csproj
@@ -1,66 +1,18 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>9.0.30729</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{-<test_client_make_guid>-}</ProjectGuid>
     <OutputType>Exe</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>TestClient</RootNamespace>
-    <AssemblyName>TestClient</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
+    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Xml.Linq">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Data.DataSetExtensions">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Program.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Library\LmcpCore.csproj">
-      <Project>{-<core_library_make_guid>-}</Project>
-      <Name>LmcpCore</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\Library\LmcpCore\LmcpCore.csproj" />
     -<all_series_csproj_references>-
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/src/templates/cs/TestServer.csproj
+++ b/src/templates/cs/TestServer.csproj
@@ -1,66 +1,18 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>9.0.30729</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{-<test_server_make_guid>-}</ProjectGuid>
     <OutputType>Exe</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>TestServer</RootNamespace>
-    <AssemblyName>TestServer</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
+    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport> 
-   <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Xml.Linq">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Data.DataSetExtensions">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Program.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Library\LmcpCore.csproj">
-      <Project>{-<core_library_make_guid>-}</Project>
-      <Name>LmcpCore</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\Library\LmcpCore\LmcpCore.csproj" />
     -<all_series_csproj_references>-
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>


### PR DESCRIPTION
Updated templates and placement of generated code for C# so all libraries generated are targeting .NET Standard (with test console applications targeting .NET Core). The main changes are as follows:

- This will require users to download dotnet core and/or upgrade to Visual Studio 2017 but provides cross-platform C# libraries (but could look into trying to find a way to tweak *.csproj temlate files to not force this)
- The folder structure had to be changed for where generated C# code is placed, but simplifies .csproj files and distinguishes which MDM each class comes from.
- Kept old, monolithic LMCP.csproj generation. Wasn't sure if this was left in there for backwards compatibility since it isn't added to the LMCP.sln, but didn't want to remove the functionality in case it was left in the code on purpose.
- The first commit made also fixed a bug. The C# generated code did not compile when pulled from master because ILmcpObject had its Version property renamed to SeriesVersion but didn't have the C# code templates reflect this change.