### PR TITLE
[C++] fixing memory leak when reading from XML.

### DIFF
--- a/src/templates/cpp/LmcpXMLReader.h
+++ b/src/templates/cpp/LmcpXMLReader.h
@@ -36,7 +36,9 @@ namespace xml {
         /** reads an LMCP XML string and returns an LMCP object */
         inline avtas::lmcp::Object* readXML(std::string input) {
             Node* el = avtas::lmcp::XMLParser::parseString(input, false);
-            return readXML(el);
+            Object* ret = readXML(el);
+            delete el;
+            return ret;
         }
 
         inline bool get_bool(Node* node) {


### PR DESCRIPTION
This fixes a memory leak observed in OpenUxAS. There, instantiating many tasks would take up an unexpected amount of memory that would not be cleaned up. This happens in TaskServiceBase.