### PR TITLE
Handle reserved words "task" and "record" and change primitive type names

### DIFF
--- a/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers.adb
+++ b/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers.adb
@@ -4,21 +4,21 @@ package body avtas.lmcp.byteBuffers is
 
 --     function To_Boolean(this : ByteBuffer) return Boolean is
 --
---     function To_Int16(this : ByteBuffer) return Int16_t is
+--     function To_Int16(this : ByteBuffer) return Int16 is
 --
---     function To_Int32(this : ByteBuffer) return Int32_t is
+--     function To_Int32(this : ByteBuffer) return Int32 is
 --
---     function To_Int64(this : ByteBuffer) return Int64_t is
+--     function To_Int64(this : ByteBuffer) return Int64 is
 --
---     function To_UInt16(this : ByteBuffer) return UInt16_t is
+--     function To_UInt16(this : ByteBuffer) return UInt16 is
 --
---     function To_UInt32(this : ByteBuffer) return UInt32_t is
+--     function To_UInt32(this : ByteBuffer) return UInt32 is
 --
---     function To_Float(this : ByteBuffer) return Float_t is
+--     function To_Real32(this : ByteBuffer) return Real32 is
 --
---     function To_Double(this : ByteBuffer) return Double_t is
+--     function To_Real64(this : ByteBuffer) return Real64 is
 --
---     function To_String(this : ByteBuffer; numBytes : UInt32_t) return Unbounded_String is
+--     function To_String(this : ByteBuffer; numBytes : UInt32) return Unbounded_String is
 --        subtype sourceType is ByteArray(1 .. numBytes);
 --        subtype targetType is Unbounded_String;
 --        function convert is new Ada.Unchecked_Conversion(Source => sourceType, Target => targetType);
@@ -38,94 +38,94 @@ package body avtas.lmcp.byteBuffers is
       this.Pos := this.Pos + 1;
    end Get_Byte;
 
-   procedure Get_Int16_t(this : in out ByteBuffer; output : out Int16_t) is
+   procedure Get_Int16(this : in out ByteBuffer; output : out Int16) is
       subtype sourceType is ByteArray2;
       subtype swapType is ByteArray2;
-      subtype targetType is Int16_t;
+      subtype targetType is Int16;
       function Convert is new Ada.Unchecked_Conversion(Source => sourceType, Target => targetType);
       function SwapBytes is new GNAT.Byte_Swapping.Swapped2 (swapType);
    begin
       output := Convert(SwapBytes(this.Buf(this.Pos .. this.Pos + 1)));
       this.Pos := this.Pos + 2;
-   end Get_Int16_t;
+   end Get_Int16;
 
-   procedure Get_Int32_t(this : in out ByteBuffer; output : out Int32_t) is
+   procedure Get_Int32(this : in out ByteBuffer; output : out Int32) is
       subtype sourceType is ByteArray4;
       subtype swapType is ByteArray4;
-      subtype targetType is Int32_t;
+      subtype targetType is Int32;
       function Convert is new Ada.Unchecked_Conversion(Source => sourceType, Target => targetType);
       function SwapBytes is new GNAT.Byte_Swapping.Swapped4 (swapType);
    begin
       output := Convert(this.Buf(this.Pos .. this.Pos + 3));
       this.Pos := this.Pos + 4;
-   end Get_Int32_t;
+   end Get_Int32;
 
-   procedure Get_Int64_t(this : in out ByteBuffer; output : out Int64_t) is
+   procedure Get_Int64(this : in out ByteBuffer; output : out Int64) is
       subtype sourceType is ByteArray8;
       subtype swapType is ByteArray8;
-      subtype targetType is Int64_t;
+      subtype targetType is Int64;
       function Convert is new Ada.Unchecked_Conversion(Source => sourceType, Target => targetType);
       function SwapBytes is new GNAT.Byte_Swapping.Swapped8 (swapType);
    begin
       output := Convert(this.Buf(this.Pos .. this.Pos + 7));
       this.Pos := this.Pos + 8;
-   end Get_Int64_t;
+   end Get_Int64;
 
-   procedure Get_UInt16_t(this : in out ByteBuffer; output : out UInt16_t) is
+   procedure Get_UInt16(this : in out ByteBuffer; output : out UInt16) is
       subtype sourceType is ByteArray2;
       subtype swapType is ByteArray2;
-      subtype targetType is UInt16_t;
+      subtype targetType is UInt16;
       function Convert is new Ada.Unchecked_Conversion(Source => sourceType, Target => targetType);
       function SwapBytes is new GNAT.Byte_Swapping.Swapped2 (swapType);
    begin
       output := Convert(this.Buf(this.Pos .. this.Pos + 1));
       this.Pos := this.Pos + 2;
-   end Get_UInt16_t;
+   end Get_UInt16;
 
-   procedure Get_UInt32_t(this : in out ByteBuffer; output : out UInt32_t) is
+   procedure Get_UInt32(this : in out ByteBuffer; output : out UInt32) is
       subtype sourceType is ByteArray4;
       subtype swapType is ByteArray4;
-      subtype targetType is UInt32_t;
+      subtype targetType is UInt32;
       function Convert is new Ada.Unchecked_Conversion(Source => sourceType, Target => targetType);
       function SwapBytes is new GNAT.Byte_Swapping.Swapped4 (swapType);
    begin
       output := Convert(this.Buf(this.Pos .. this.Pos + 3));
       this.Pos := this.Pos + 4;
-   end Get_UInt32_t;
+   end Get_UInt32;
 
-   procedure Get_Float_t(this : in out ByteBuffer; output : out Float_t) is
+   procedure Get_Real32(this : in out ByteBuffer; output : out Real32) is
       subtype sourceType is ByteArray4;
       subtype swapType is ByteArray4;
-      subtype targetType is Float_t;
+      subtype targetType is Real32;
       function Convert is new Ada.Unchecked_Conversion(Source => sourceType, Target => targetType);
       function SwapBytes is new GNAT.Byte_Swapping.Swapped4 (swapType);
    begin
       output := Convert(this.Buf(this.Pos .. this.Pos + 3));
       this.Pos := this.Pos + 4;
-   end Get_Float_t;
+   end Get_Real32;
 
-   procedure Get_Double_t(this : in out ByteBuffer; output : out Double_t) is
+   procedure Get_Real64(this : in out ByteBuffer; output : out Real64) is
       subtype sourceType is ByteArray8;
       subtype swapType is ByteArray8;
-      subtype targetType is Double_t;
+      subtype targetType is Real64;
       function Convert is new Ada.Unchecked_Conversion(Source => sourceType, Target => targetType);
       function SwapBytes is new GNAT.Byte_Swapping.Swapped8 (swapType);
    begin
       output := Convert(this.Buf(this.Pos .. this.Pos + 7));
       this.Pos := this.Pos + 8;
-   end Get_Double_t;
+   end Get_Real64;
 
    procedure Get_Unbounded_String(this : in out ByteBuffer; output : out Unbounded_String) is
-      numBytes : UInt16_t;
+      numBytes : UInt16;
    begin
-      Get_UInt16_t(this, numBytes);
+      Get_UInt16(this, numBytes);
       declare
-         subtype sourceType is ByteArray(1 .. UInt32_t(numBytes));
+         subtype sourceType is ByteArray(1 .. UInt32(numBytes));
          subtype targetType is Unbounded_String;
          function convert is new Ada.Unchecked_Conversion(Source => sourceType, Target => targetType);
       begin
-         output := convert(this.Buf(this.Pos .. this.Pos + UInt32_t(numBytes) - 1));
-         this.Pos := this.Pos + UInt32_t(numBytes);
+         output := convert(this.Buf(this.Pos .. this.Pos + UInt32(numBytes) - 1));
+         this.Pos := this.Pos + UInt32(numBytes);
       end;
    end Get_Unbounded_String;
 
@@ -141,8 +141,8 @@ package body avtas.lmcp.byteBuffers is
       this.Pos := this.Pos + 1;
    end Put_Byte;
 
-   procedure Put_Int16_t(input : in Int16_t; this :  in out ByteBuffer) is
-      subtype sourceType is Int16_t;
+   procedure Put_Int16(input : in Int16; this :  in out ByteBuffer) is
+      subtype sourceType is Int16;
       subtype targetType is ByteArray2;
       function Convert is new Ada.Unchecked_Conversion(Source => sourceType, Target => targetType);
       subtype swapType is ByteArray2;
@@ -150,10 +150,10 @@ package body avtas.lmcp.byteBuffers is
    begin
       this.Buf(this.Pos .. this.Pos + 1) := SwapBytes(Convert(input));
       this.Pos := this.Pos + 2;
-   end Put_Int16_t;
+   end Put_Int16;
 
-   procedure Put_Int32_t(input : in Int32_t; this :  in out ByteBuffer) is
-      subtype sourceType is Int32_t;
+   procedure Put_Int32(input : in Int32; this :  in out ByteBuffer) is
+      subtype sourceType is Int32;
       subtype targetType is ByteArray4;
       function Convert is new Ada.Unchecked_Conversion(Source => sourceType, Target => targetType);
       subtype swapType is ByteArray4;
@@ -161,10 +161,10 @@ package body avtas.lmcp.byteBuffers is
    begin
       this.Buf(this.Pos .. this.Pos + 3) := SwapBytes(Convert(input));
       this.Pos := this.Pos + 4;
-   end Put_Int32_t;
+   end Put_Int32;
 
-   procedure Put_Int64_t(input : in Int64_t; this :  in out ByteBuffer) is
-      subtype sourceType is Int64_t;
+   procedure Put_Int64(input : in Int64; this :  in out ByteBuffer) is
+      subtype sourceType is Int64;
       subtype targetType is ByteArray8;
       function Convert is new Ada.Unchecked_Conversion(Source => sourceType, Target => targetType);
       subtype swapType is ByteArray8;
@@ -172,10 +172,10 @@ package body avtas.lmcp.byteBuffers is
    begin
       this.Buf(this.Pos .. this.Pos + 7) := SwapBytes(Convert(input));
       this.Pos := this.Pos + 8;
-   end Put_Int64_t;
+   end Put_Int64;
 
-   procedure Put_UInt16_t(input : in UInt16_t; this :  in out ByteBuffer) is
-      subtype sourceType is UInt16_t;
+   procedure Put_UInt16(input : in UInt16; this :  in out ByteBuffer) is
+      subtype sourceType is UInt16;
       subtype targetType is ByteArray2;
       function Convert is new Ada.Unchecked_Conversion(Source => sourceType, Target => targetType);
       subtype swapType is ByteArray2;
@@ -183,10 +183,10 @@ package body avtas.lmcp.byteBuffers is
    begin
       this.Buf(this.Pos .. this.Pos + 1) := SwapBytes(Convert(input));
       this.Pos := this.Pos + 2;
-   end Put_UInt16_t;
+   end Put_UInt16;
 
-   procedure Put_UInt32_t(input : in UInt32_t; this :  in out ByteBuffer) is
-      subtype sourceType is UInt32_t;
+   procedure Put_UInt32(input : in UInt32; this :  in out ByteBuffer) is
+      subtype sourceType is UInt32;
       subtype targetType is ByteArray4;
       function Convert is new Ada.Unchecked_Conversion(Source => sourceType, Target => targetType);
       subtype swapType is ByteArray4;
@@ -194,10 +194,10 @@ package body avtas.lmcp.byteBuffers is
    begin
       this.Buf(this.Pos .. this.Pos + 3) := SwapBytes(Convert(input));
       this.Pos := this.Pos + 4;
-   end Put_UInt32_t;
+   end Put_UInt32;
 
-   procedure Put_Float_t(input : in Float_t; this :  in out ByteBuffer) is
-      subtype sourceType is Float_t;
+   procedure Put_Real32(input : in Real32; this :  in out ByteBuffer) is
+      subtype sourceType is Real32;
       subtype targetType is ByteArray4;
       function Convert is new Ada.Unchecked_Conversion(Source => sourceType, Target => targetType);
       subtype swapType is ByteArray4;
@@ -205,10 +205,10 @@ package body avtas.lmcp.byteBuffers is
    begin
       this.Buf(this.Pos .. this.Pos + 3) := SwapBytes(Convert(input));
       this.Pos := this.Pos + 4;
-   end Put_Float_t;
+   end Put_Real32;
 
-   procedure Put_Double_t(input : in Double_t; this :  in out ByteBuffer) is
-      subtype sourceType is Double_t;
+   procedure Put_Real64(input : in Real64; this :  in out ByteBuffer) is
+      subtype sourceType is Real64;
       subtype targetType is ByteArray8;
       function Convert is new Ada.Unchecked_Conversion(Source => sourceType, Target => targetType);
       subtype swapType is ByteArray8;
@@ -216,19 +216,19 @@ package body avtas.lmcp.byteBuffers is
    begin
       this.Buf(this.Pos .. this.Pos + 7) := SwapBytes(Convert(input));
       this.Pos := this.Pos + 8;
-   end Put_Double_t;
+   end Put_Real64;
 
    procedure Put_Unbounded_String(input : in Unbounded_String; this :  in out ByteBuffer) is
       subtype sourceType is Unbounded_String;
-      subtype targetType is ByteArray(1 .. UInt32_t(Length(input)));
+      subtype targetType is ByteArray(1 .. UInt32(Length(input)));
       function convert is new Ada.Unchecked_Conversion(Source => sourceType, Target => targetType);
    begin
-      Put_UInt16_t(UInt16_t(Length(input)), this);
-      this.Buf(this.Pos .. this.Pos + UInt32_t(Length(input))) := Convert(input);
-      this.Pos := this.Pos + UInt32_t(Length(input));
+      Put_UInt16(UInt16(Length(input)), this);
+      this.Buf(this.Pos .. this.Pos + UInt32(Length(input))) := Convert(input);
+      this.Pos := this.Pos + UInt32(Length(input));
    end Put_Unbounded_String;
 
---     function To_BooleanArray(this : ByteBuffer; numBytes : UInt32_t) return BooleanArray is
+--     function To_BooleanArray(this : ByteBuffer; numBytes : UInt32) return BooleanArray is
 --        subtype sourceType is ByteArray(1 .. numBytes);
 --        subtype targetType is BooleanArray(1 .. numBytes);
 --        function convert is new Ada.Unchecked_Conversion(Source => sourceType, Target => targetType);
@@ -236,7 +236,7 @@ package body avtas.lmcp.byteBuffers is
 --        return Convert(this.Buf(this.Pos .. this.Pos + numBytes - 1));
 --     end To_BooleanArray;
 --
---     function To_Int16Array (this : ByteBuffer; numBytes : UInt32_t) return Int16Array is
+--     function To_Int16Array (this : ByteBuffer; numBytes : UInt32) return Int16Array is
 --        subtype sourceType is ByteArray(1 .. numBytes);
 --        subtype targetType is Int16Array(1 .. numBytes/2);
 --        function convert is new Ada.Unchecked_Conversion(Source => sourceType, Target => targetType);
@@ -250,7 +250,7 @@ package body avtas.lmcp.byteBuffers is
 --        return convert(tempArray);
 --     end To_Int16Array;
 --
---     function To_Int32Array (this : ByteBuffer; numBytes : UInt32_t) return Int32Array is
+--     function To_Int32Array (this : ByteBuffer; numBytes : UInt32) return Int32Array is
 --        subtype sourceType is ByteArray(1 .. numBytes);
 --        subtype targetType is Int32Array(1 .. numBytes/4);
 --        function convert is new Ada.Unchecked_Conversion(Source => sourceType, Target => targetType);
@@ -264,7 +264,7 @@ package body avtas.lmcp.byteBuffers is
 --        return convert(tempArray);
 --     end To_Int32Array;
 --
---     function To_Int64Array (this : ByteBuffer; numBytes : UInt32_t) return Int64Array is
+--     function To_Int64Array (this : ByteBuffer; numBytes : UInt32) return Int64Array is
 --        subtype sourceType is ByteArray(1 .. numBytes);
 --        subtype targetType is Int64Array(1 .. numBytes/8);
 --        function convert is new Ada.Unchecked_Conversion(Source => sourceType, Target => targetType);
@@ -278,7 +278,7 @@ package body avtas.lmcp.byteBuffers is
 --        return convert(tempArray);
 --     end To_Int64Array;
 --
---     function To_UInt16Array (this : ByteBuffer; numBytes : UInt32_t) return UInt16Array is
+--     function To_UInt16Array (this : ByteBuffer; numBytes : UInt32) return UInt16Array is
 --        subtype sourceType is ByteArray(1 .. numBytes);
 --        subtype targetType is UInt16Array(1 .. numBytes/2);
 --        function convert is new Ada.Unchecked_Conversion(Source => sourceType, Target => targetType);
@@ -292,7 +292,7 @@ package body avtas.lmcp.byteBuffers is
 --        return convert(tempArray);
 --     end To_UInt16Array;
 --
---     function To_UInt32Array (this : ByteBuffer; numBytes : UInt32_t) return UInt32Array is
+--     function To_UInt32Array (this : ByteBuffer; numBytes : UInt32) return UInt32Array is
 --        subtype sourceType is ByteArray(1 .. numBytes);
 --        subtype targetType is UInt32Array(1 .. numBytes/4);
 --        function convert is new Ada.Unchecked_Conversion(Source => sourceType, Target => targetType);
@@ -306,9 +306,9 @@ package body avtas.lmcp.byteBuffers is
 --        return convert(tempArray);
 --     end To_UInt32Array;
 --
---     function To_FloatArray(this : ByteBuffer; numBytes : UInt32_t) return FloatArray is
+--     function To_Real32Array(this : ByteBuffer; numBytes : UInt32) return Real32Array is
 --        subtype sourceType is ByteArray(1 .. numBytes);
---        subtype targetType is FloatArray(1 .. numBytes/4);
+--        subtype targetType is Real32Array(1 .. numBytes/4);
 --        function convert is new Ada.Unchecked_Conversion(Source => sourceType, Target => targetType);
 --        subtype swapType is ByteArray(1 .. 4);
 --        function SwapBytes is new GNAT.Byte_Swapping.Swapped4 (swapType);
@@ -318,11 +318,11 @@ package body avtas.lmcp.byteBuffers is
 --           tempArray(Nat(4*i - 3) .. Nat(4*i)) := SwapBytes(tempArray(Nat(4*i - 3) .. Nat(4*i)));
 --        end loop;
 --        return convert(tempArray);
---     end To_FloatArray;
+--     end To_Real32Array;
 --
---     function To_DoubleArray(this : ByteBuffer; numBytes : UInt32_t) return DoubleArray is
+--     function To_Real64Array(this : ByteBuffer; numBytes : UInt32) return Real64Array is
 --        subtype sourceType is ByteArray(1 .. numBytes);
---        subtype targetType is DoubleArray(1 .. numBytes/8);
+--        subtype targetType is Real64Array(1 .. numBytes/8);
 --        function convert is new Ada.Unchecked_Conversion(Source => sourceType, Target => targetType);
 --        subtype swapType is ByteArray(1 .. 8);
 --        function SwapBytes is new GNAT.Byte_Swapping.Swapped8 (swapType);
@@ -332,12 +332,12 @@ package body avtas.lmcp.byteBuffers is
 --           tempArray(Nat(8*i - 7) .. Nat(8*i)) := SwapBytes(tempArray(Nat(8*i - 7) .. Nat(8*i)));
 --        end loop;
 --        return convert(tempArray);
---     end To_DoubleArray;
+--     end To_Real64Array;
 --
 --     function To_StringArray(Input : ByteArray) return StringArray is
---        arrayElements : UInt16_t := To_UInt16(ByteArray2(Input(1 .. 2)));
---        position : UInt32_t := 3;
---        stringLength : UInt16_t;
+--        arrayElements : UInt16 := To_UInt16(ByteArray2(Input(1 .. 2)));
+--        position : UInt32 := 3;
+--        stringLength : UInt16;
 --        tempString : Unbounded_String;
 --        output : StringArray(Nat(1) .. Nat(arrayElements));
 --        function convert is new Ada.Unchecked_Conversion(Source => Byte, Target => Character);
@@ -353,7 +353,7 @@ package body avtas.lmcp.byteBuffers is
 --           for j in 1 .. stringLength loop
 --              tempString := tempString & convert(Input(Nat(position) + Nat(j) - Nat(1)));
 --           end loop;
---           position := position + UInt32_t(stringLength);
+--           position := position + UInt32(stringLength);
 --           output(Nat(i)) := tempString;
 --        end loop;
 --        return output;
@@ -367,7 +367,7 @@ package body avtas.lmcp.byteBuffers is
 --        return Convert(this.Buf(this.Pos .. this.Pos + numBytes - 1));
 --     end To_BooleanArray;
 --  
---     function To_Int16Array (this : ByteBuffer; numBytes : UInt32_t) return Int16Array is
+--     function To_Int16Array (this : ByteBuffer; numBytes : UInt32) return Int16Array is
 --        subtype sourceType is ByteArray(1 .. numBytes);
 --        subtype targetType is Int16Array(1 .. numBytes/2);
 --        function convert is new Ada.Unchecked_Conversion(Source => sourceType, Target => targetType);
@@ -381,7 +381,7 @@ package body avtas.lmcp.byteBuffers is
 --        return convert(tempArray);
 --     end To_Int16Array;
 --  
---     function To_Int32Array (this : ByteBuffer; numBytes : UInt32_t) return Int32Array is
+--     function To_Int32Array (this : ByteBuffer; numBytes : UInt32) return Int32Array is
 --        subtype sourceType is ByteArray(1 .. numBytes);
 --        subtype targetType is Int32Array(1 .. numBytes/4);
 --        function convert is new Ada.Unchecked_Conversion(Source => sourceType, Target => targetType);
@@ -395,7 +395,7 @@ package body avtas.lmcp.byteBuffers is
 --        return convert(tempArray);
 --     end To_Int32Array;
 --  
---     function To_Int64Array (this : ByteBuffer; numBytes : UInt32_t) return Int64Array is
+--     function To_Int64Array (this : ByteBuffer; numBytes : UInt32) return Int64Array is
 --        subtype sourceType is ByteArray(1 .. numBytes);
 --        subtype targetType is Int64Array(1 .. numBytes/8);
 --        function convert is new Ada.Unchecked_Conversion(Source => sourceType, Target => targetType);
@@ -409,7 +409,7 @@ package body avtas.lmcp.byteBuffers is
 --        return convert(tempArray);
 --     end To_Int64Array;
 --  
---     function To_UInt16Array (this : ByteBuffer; numBytes : UInt32_t) return UInt16Array is
+--     function To_UInt16Array (this : ByteBuffer; numBytes : UInt32) return UInt16Array is
 --        subtype sourceType is ByteArray(1 .. numBytes);
 --        subtype targetType is UInt16Array(1 .. numBytes/2);
 --        function convert is new Ada.Unchecked_Conversion(Source => sourceType, Target => targetType);
@@ -423,7 +423,7 @@ package body avtas.lmcp.byteBuffers is
 --        return convert(tempArray);
 --     end To_UInt16Array;
 --  
---     function To_UInt32Array (this : ByteBuffer; numBytes : UInt32_t) return UInt32Array is
+--     function To_UInt32Array (this : ByteBuffer; numBytes : UInt32) return UInt32Array is
 --        subtype sourceType is ByteArray(1 .. numBytes);
 --        subtype targetType is UInt32Array(1 .. numBytes/4);
 --        function convert is new Ada.Unchecked_Conversion(Source => sourceType, Target => targetType);
@@ -437,9 +437,9 @@ package body avtas.lmcp.byteBuffers is
 --        return convert(tempArray);
 --     end To_UInt32Array;
 --  
---     function To_FloatArray(this : ByteBuffer; numBytes : UInt32_t) return FloatArray is
+--     function To_Real32Array(this : ByteBuffer; numBytes : UInt32) return Real32Array is
 --        subtype sourceType is ByteArray(1 .. numBytes);
---        subtype targetType is FloatArray(1 .. numBytes/4);
+--        subtype targetType is Real32Array(1 .. numBytes/4);
 --        function convert is new Ada.Unchecked_Conversion(Source => sourceType, Target => targetType);
 --        subtype swapType is ByteArray(1 .. 4);
 --        function SwapBytes is new GNAT.Byte_Swapping.Swapped4 (swapType);
@@ -449,11 +449,11 @@ package body avtas.lmcp.byteBuffers is
 --           tempArray(Nat(4*i - 3) .. Nat(4*i)) := SwapBytes(tempArray(Nat(4*i - 3) .. Nat(4*i)));
 --        end loop;
 --        return convert(tempArray);
---     end To_FloatArray;
+--     end To_Real32Array;
 --  
---     function To_DoubleArray(this : ByteBuffer; numBytes : UInt32_t) return DoubleArray is
+--     function To_Real64Array(this : ByteBuffer; numBytes : UInt32) return Real64Array is
 --        subtype sourceType is ByteArray(1 .. numBytes);
---        subtype targetType is DoubleArray(1 .. numBytes/8);
+--        subtype targetType is Real64Array(1 .. numBytes/8);
 --        function convert is new Ada.Unchecked_Conversion(Source => sourceType, Target => targetType);
 --        subtype swapType is ByteArray(1 .. 8);
 --        function SwapBytes is new GNAT.Byte_Swapping.Swapped8 (swapType);
@@ -463,12 +463,12 @@ package body avtas.lmcp.byteBuffers is
 --           tempArray(Nat(8*i - 7) .. Nat(8*i)) := SwapBytes(tempArray(Nat(8*i - 7) .. Nat(8*i)));
 --        end loop;
 --        return convert(tempArray);
---     end To_DoubleArray;
+--     end To_Real64Array;
 --  
 --     function To_StringArray(Input : ByteArray) return StringArray is
---        arrayElements : UInt16_t := To_UInt16(ByteArray2(Input(1 .. 2)));
---        position : UInt32_t := 3;
---        stringLength : UInt16_t;
+--        arrayElements : UInt16 := To_UInt16(ByteArray2(Input(1 .. 2)));
+--        position : UInt32 := 3;
+--        stringLength : UInt16;
 --        tempString : Unbounded_String;
 --        output : StringArray(Nat(1) .. Nat(arrayElements));
 --        function convert is new Ada.Unchecked_Conversion(Source => Byte, Target => Character);
@@ -484,7 +484,7 @@ package body avtas.lmcp.byteBuffers is
 --           for j in 1 .. stringLength loop
 --              tempString := tempString & convert(Input(Nat(position) + Nat(j) - Nat(1)));
 --           end loop;
---           position := position + UInt32_t(stringLength);
+--           position := position + UInt32(stringLength);
 --           output(Nat(i)) := tempString;
 --        end loop;
 --        return output;
@@ -495,7 +495,7 @@ package body avtas.lmcp.byteBuffers is
       this.Pos := position;
    end setPosition;
 
-   procedure incrementPosition(this : in out ByteBuffer; amount : in UInt32_t) is
+   procedure incrementPosition(this : in out ByteBuffer; amount : in UInt32) is
    begin
       if(amount > 0) then
          this.Pos := this.Pos + Nat(amount);

--- a/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers.ads
+++ b/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers.ads
@@ -6,19 +6,19 @@ with Ada.Strings.Unbounded; use Ada.Strings.Unbounded;
 
 package avtas.lmcp.byteBuffers is
    
-   subtype Nat is UInt32_t range 1 .. UInt32_t'Last;
+   subtype Nat is UInt32 range 1 .. UInt32'Last;
    type ByteArray is array (Nat range <>) of Byte;
    subtype ByteArray2 is ByteArray(1 .. 2);
    subtype ByteArray4 is ByteArray(1 .. 4);
    subtype ByteArray8 is ByteArray(1 .. 8);
    
-   type Int16Array is array (Nat range <>) of Int16_t;
-   type Int32Array is array (Nat range <>) of Int32_t;
-   type Int64Array is array (Nat range <>) of Int64_t;
-   type UInt16Array is array (Nat range <>) of UInt16_t;
-   type UInt32Array is array (Nat range <>) of UInt32_t;
-   type FloatArray is array (Nat range <>) of Float_t;
-   type DoubleArray is array (Nat range <>) of Double_t;
+   type Int16Array is array (Nat range <>) of Int16;
+   type Int32Array is array (Nat range <>) of Int32;
+   type Int64Array is array (Nat range <>) of Int64;
+   type UInt16Array is array (Nat range <>) of UInt16;
+   type UInt32Array is array (Nat range <>) of UInt32;
+   type FloatArray is array (Nat range <>) of Real32;
+   type DoubleArray is array (Nat range <>) of Real64;
    type StringArray is array (Nat range <>) of Unbounded_String;
    type BooleanArray is array (Nat range <>) of Boolean;
    
@@ -28,46 +28,46 @@ package avtas.lmcp.byteBuffers is
    end record;
    
 --     function To_Boolean(this : ByteBuffer) return Boolean;
---     function To_Int16(this : ByteBuffer) return Int16_t;
---     function To_Int32(this : ByteBuffer) return Int32_t;
---     function To_Int64(this : ByteBuffer) return Int64_t;
---     function To_UInt16(this : ByteBuffer) return UInt16_t;
---     function To_UInt32(this : ByteBuffer) return UInt32_t;
---     function To_Float(this : ByteBuffer) return Float_t;
---     function To_Double(this : ByteBuffer) return Double_t;
---     function To_String(this : ByteBuffer; numBytes : UInt32_t) return Unbounded_String;
+--     function To_Int16(this : ByteBuffer) return Int16;
+--     function To_Int32(this : ByteBuffer) return Int32;
+--     function To_Int64(this : ByteBuffer) return Int64;
+--     function To_UInt16(this : ByteBuffer) return UInt16;
+--     function To_UInt32(this : ByteBuffer) return UInt32;
+--     function To_Float(this : ByteBuffer) return Real32;
+--     function To_Double(this : ByteBuffer) return Real64;
+--     function To_String(this : ByteBuffer; numBytes : UInt32) return Unbounded_String;
    
    procedure Get_Boolean(this : in out ByteBuffer; output : out Boolean);
    procedure Get_Byte(this : in out ByteBuffer; output : out Byte);
-   procedure Get_Int16_t(this : in out ByteBuffer; output : out Int16_t);
-   procedure Get_Int32_t(this : in out ByteBuffer; output : out Int32_t);
-   procedure Get_Int64_t(this : in out ByteBuffer; output : out Int64_t);
-   procedure Get_UInt16_t(this : in out ByteBuffer; output : out UInt16_t);
-   procedure Get_UInt32_t(this : in out ByteBuffer; output : out UInt32_t);
-   procedure Get_Float_t(this : in out ByteBuffer; output : out Float_t);
-   procedure Get_Double_t(this : in out ByteBuffer; output : out Double_t);
+   procedure Get_Int16(this : in out ByteBuffer; output : out Int16);
+   procedure Get_Int32(this : in out ByteBuffer; output : out Int32);
+   procedure Get_Int64(this : in out ByteBuffer; output : out Int64);
+   procedure Get_UInt16(this : in out ByteBuffer; output : out UInt16);
+   procedure Get_UInt32(this : in out ByteBuffer; output : out UInt32);
+   procedure Get_Real32(this : in out ByteBuffer; output : out Real32);
+   procedure Get_Real64(this : in out ByteBuffer; output : out Real64);
    procedure Get_Unbounded_String(this : in out ByteBuffer; output : out Unbounded_String);
    
    procedure Put_Boolean(input : in Boolean; this : in out ByteBuffer);
    procedure Put_Byte(input : in Byte; this : in out ByteBuffer);
-   procedure Put_Int16_t(input : in Int16_t; this :  in out ByteBuffer);
-   procedure Put_Int32_t(input : in Int32_t; this :  in out ByteBuffer);
-   procedure Put_Int64_t(input : in Int64_t; this :  in out ByteBuffer);
-   procedure Put_UInt16_t(input : in UInt16_t; this :  in out ByteBuffer);
-   procedure Put_UInt32_t(input : in UInt32_t; this :  in out ByteBuffer);
-   procedure Put_Float_t(input : in Float_t; this :  in out ByteBuffer);
-   procedure Put_Double_t(input : in Double_t; this :  in out ByteBuffer);
+   procedure Put_Int16(input : in Int16; this :  in out ByteBuffer);
+   procedure Put_Int32(input : in Int32; this :  in out ByteBuffer);
+   procedure Put_Int64(input : in Int64; this :  in out ByteBuffer);
+   procedure Put_UInt16(input : in UInt16; this :  in out ByteBuffer);
+   procedure Put_UInt32(input : in UInt32; this :  in out ByteBuffer);
+   procedure Put_Real32(input : in Real32; this :  in out ByteBuffer);
+   procedure Put_Real64(input : in Real64; this :  in out ByteBuffer);
    procedure Put_Unbounded_String(input : in Unbounded_String; this : in out ByteBuffer);
    
---     function To_BooleanArray(this : ByteBuffer; numBytes : UInt32_t) return BooleanArray;
---     function To_StringArray(this : ByteBuffer; numBytes : UInt32_t) return StringArray;
---     function To_Int16Array(this : ByteBuffer; numBytes : UInt32_t) return Int16Array;
---     function To_Int32Array(this : ByteBuffer; numBytes : UInt32_t) return Int32Array;
---     function To_Int64Array(this : ByteBuffer; numBytes : UInt32_t) return Int64Array;
---     function To_UInt16Array(this : ByteBuffer; numBytes : UInt32_t) return UInt16Array;
---     function To_UInt32Array(this : ByteBuffer; numBytes : UInt32_t) return UInt32Array;
---     function To_FloatArray(this : ByteBuffer; numBytes : UInt32_t) return FloatArray;
---     function To_DoubleArray(this : ByteBuffer; numBytes : UInt32_t) return DoubleArray;
+--     function To_BooleanArray(this : ByteBuffer; numBytes : UInt32) return BooleanArray;
+--     function To_StringArray(this : ByteBuffer; numBytes : UInt32) return StringArray;
+--     function To_Int16Array(this : ByteBuffer; numBytes : UInt32) return Int16Array;
+--     function To_Int32Array(this : ByteBuffer; numBytes : UInt32) return Int32Array;
+--     function To_Int64Array(this : ByteBuffer; numBytes : UInt32) return Int64Array;
+--     function To_UInt16Array(this : ByteBuffer; numBytes : UInt32) return UInt16Array;
+--     function To_UInt32Array(this : ByteBuffer; numBytes : UInt32) return UInt32Array;
+--     function To_FloatArray(this : ByteBuffer; numBytes : UInt32) return FloatArray;
+--     function To_DoubleArray(this : ByteBuffer; numBytes : UInt32) return DoubleArray;
 
 --   procedure Get_BooleanArray(this : in out ByteBuffer; output: out BooleanArray; isLarge : in Boolean);
 --   procedure Get_StringArray(this : in out ByteBuffer; output: out StringArray; isLarge : in Boolean);
@@ -83,26 +83,26 @@ package avtas.lmcp.byteBuffers is
    -- little endian. So it is necessary to swap bytes first before doing the unchecked conversion.
    
 --     function To_Int16 is
---       new Ada.Unchecked_Conversion (Source => ByteArray2, Target => Int16_t);
+--       new Ada.Unchecked_Conversion (Source => ByteArray2, Target => Int16);
 --     function To_Int32 is
---       new Ada.Unchecked_Conversion (Source => ByteArray4, Target => Int32_t);
+--       new Ada.Unchecked_Conversion (Source => ByteArray4, Target => Int32);
 --     function To_Int64 is
---       new Ada.Unchecked_Conversion (Source => ByteArray8, Target => Int64_t);
+--       new Ada.Unchecked_Conversion (Source => ByteArray8, Target => Int64);
 --     function To_UInt16 is
---       new Ada.Unchecked_Conversion (Source => ByteArray2, Target => UInt16_t);
+--       new Ada.Unchecked_Conversion (Source => ByteArray2, Target => UInt16);
 --     function To_UInt32 is
---       new Ada.Unchecked_Conversion (Source => ByteArray4, Target => UInt32_t);
+--       new Ada.Unchecked_Conversion (Source => ByteArray4, Target => UInt32);
 --     function To_Float is
---       new Ada.Unchecked_Conversion (Source => ByteArray4, Target => Float_t);
+--       new Ada.Unchecked_Conversion (Source => ByteArray4, Target => Real32);
 --     function To_Double is
---       new Ada.Unchecked_Conversion (Source => ByteArray8, Target => Double_t);
+--       new Ada.Unchecked_Conversion (Source => ByteArray8, Target => Real64);
    
    function capacity(this : ByteBuffer) return Nat is (this.Capacity);
    function getPosition(this : ByteBuffer) return Nat is (this.Pos);
-   function remaining(this : ByteBuffer) return UInt32_t is (UInt32_t(this.Capacity - this.Pos));
+   function remaining(this : ByteBuffer) return UInt32 is (UInt32(this.Capacity - this.Pos));
    function hasRemaining(this : ByteBuffer) return Boolean is (this.Pos < this.Capacity);
    
    procedure setPosition(this : in out ByteBuffer; position : in Nat);
-   procedure incrementPosition(this : in out ByteBuffer; amount : in UInt32_t);
+   procedure incrementPosition(this : in out ByteBuffer; amount : in UInt32);
    
 end avtas.lmcp.byteBuffers;

--- a/src/templates/ada/avtas/lmcp/avtas-lmcp-factory.ads
+++ b/src/templates/ada/avtas/lmcp/avtas-lmcp-factory.ads
@@ -5,17 +5,17 @@ with avtas.lmcp.types; use avtas.lmcp.types;
 
 package avtas.lmcp.factory is
 
-   HEADER_SIZE : constant UInt32_t := 8;
-   CHECKSUM_SIZE : constant UInt32_t := 4;
-   SERIESNAME_SIZE : constant UInt32_t := 8;
-   LMCP_CONTROL_STR : constant Int32_t := 16#4c4d4350#;
+   HEADER_SIZE : constant UInt32 := 8;
+   CHECKSUM_SIZE : constant UInt32 := 4;
+   SERIESNAME_SIZE : constant UInt32 := 8;
+   LMCP_CONTROL_STR : constant Int32 := 16#4c4d4350#;
    
    function packMessage(rootObject : in avtas.lmcp.object.Object_Any; enableChecksum : in Boolean) return ByteBuffer;
    procedure putObject(object : in avtas.lmcp.object.Object_Any; buffer : in out ByteBuffer);
    procedure getObject(buffer : in out ByteBuffer; output : out avtas.lmcp.object.Object_Any);
-   function createObject(seriesId : in Int64_t;  msgType : in UInt32_t; version: in UInt16_t) return avtas.lmcp.object.Object_Any;
-   function calculateChecksum(buffer : in ByteBuffer) return UInt32_t;
-   function getObjectSize(buffer : in ByteBuffer) return UInt32_t;
+   function createObject(seriesId : in Int64;  msgType : in UInt32; version: in UInt16) return avtas.lmcp.object.Object_Any;
+   function calculateChecksum(buffer : in ByteBuffer) return UInt32;
+   function getObjectSize(buffer : in ByteBuffer) return UInt32;
    function validate(buffer : in ByteBuffer) return Boolean;
 
 end avtas.lmcp.factory;

--- a/src/templates/ada/avtas/lmcp/avtas-lmcp-object.ads
+++ b/src/templates/ada/avtas/lmcp/avtas-lmcp-object.ads
@@ -15,15 +15,15 @@ package avtas.lmcp.object is
    
    function getFullLmcpTypeName(this : Object) return String is ("avtas.lmcp.object.Object");
    
-   function getLmcpType(this : Object) return UInt32_t is (0);
+   function getLmcpType(this : Object) return UInt32 is (0);
    
    function getSeriesName(this : Object) return String is ("");
    
-   function getSeriesNameAsLong(this : Object) return Int64_t is (0);
+   function getSeriesNameAsLong(this : Object) return Int64 is (0);
    
-   function getSeriesVersion(this : Object) return UInt16_t is (0);
+   function getSeriesVersion(this : Object) return UInt16 is (0);
 
-   function calculatePackedSize(this : Object) return UInt32_t is (0);
+   function calculatePackedSize(this : Object) return UInt32 is (0);
 
    procedure pack(object_acc : in Object_Any; buf : in out ByteBuffer);
    procedure unpack(buf : in out ByteBuffer; object_acc : in out Object_Any);

--- a/src/templates/ada/avtas/lmcp/avtas-lmcp-types.ads
+++ b/src/templates/ada/avtas/lmcp/avtas-lmcp-types.ads
@@ -3,13 +3,13 @@ with Interfaces; use Interfaces;
 package avtas.lmcp.types is
    
    -- C/C++ compatible integer types
-   type Byte is new Interfaces.Unsigned_8;
-   type UInt16_t is new Interfaces.Unsigned_16;
-   type UInt32_t is new Interfaces.Unsigned_32;
-   type Int16_t is new Interfaces.Integer_16;
-   type Int32_t is new Interfaces.Integer_32;
-   type Int64_t is new Interfaces.Integer_64;
-   type Float_t is new Interfaces.IEEE_Float_32;
-   type Double_t is new Interfaces.IEEE_Float_64;
+   type Byte   is new Interfaces.Unsigned_8;
+   type UInt16 is new Interfaces.Unsigned_16;
+   type UInt32 is new Interfaces.Unsigned_32;
+   type Int16  is new Interfaces.Integer_16;
+   type Int32  is new Interfaces.Integer_32;
+   type Int64  is new Interfaces.Integer_64;
+   type Real32 is new Interfaces.IEEE_Float_32;
+   type Real64 is new Interfaces.IEEE_Float_64;
 
 end avtas.lmcp.types;

--- a/src/templates/ada/mdm-factory.adb
+++ b/src/templates/ada/mdm-factory.adb
@@ -5,7 +5,7 @@ with GNAT.Byte_Swapping;
 package body -<full_series_name_dots>-.factory is
 
    function packMessage(rootObject : in avtas.lmcp.object.Object_Any; enableChecksum : in Boolean) return ByteBuffer is
-      msgSize : UInt32_t;
+      msgSize : UInt32;
    begin
       -- Allocate space for message, with 15 extra bytes for
       --  Existence (1 byte), series name (8 bytes), type (4 bytes), version number (2 bytes)
@@ -14,43 +14,43 @@ package body -<full_series_name_dots>-.factory is
          buffer : ByteBuffer(HEADER_SIZE + msgSize + CHECKSUM_SIZE);
       begin
          -- add header values
-         Put_Int32_t(LMCP_CONTROL_STR, buffer);
-         Put_UInt32_t(msgSize, buffer);
+         Put_Int32(LMCP_CONTROL_STR, buffer);
+         Put_UInt32(msgSize, buffer);
 
          -- If root object is null, pack a 0; otherwise, add root object
          if(rootObject = null) then
             Put_Boolean(False, buffer);
          else
             Put_Boolean(True, buffer);
-            Put_Int64_t(rootObject.getSeriesNameAsLong, buffer);
-            Put_UInt32_t(rootObject.getLmcpType, buffer);
-            Put_UInt16_t(rootObject.getSeriesVersion, buffer);
+            Put_Int64(rootObject.getSeriesNameAsLong, buffer);
+            Put_UInt32(rootObject.getLmcpType, buffer);
+            Put_UInt16(rootObject.getSeriesVersion, buffer);
             pack(rootObject, buffer);
          end if;
 
          -- add checksum if enabled
-         Put_UInt32_t((if enableChecksum then calculateChecksum(buffer) else 0), buffer);
+         Put_UInt32((if enableChecksum then calculateChecksum(buffer) else 0), buffer);
          return buffer;
       end;
    end packMessage;
 
    procedure getObject(buffer : in out ByteBuffer; output : out avtas.lmcp.object.Object_Any) is
-      ctrlStr : Int32_t;
-      msgSize : UInt32_t;
+      ctrlStr : Int32;
+      msgSize : UInt32;
       msgExists : Boolean;
-      seriesId : Int64_t;
-      msgType : Uint32_t;
-      version : Uint16_t;
+      seriesId : Int64;
+      msgType : Uint32;
+      version : Uint16;
    begin
       -- TODO: add some kind of warning/error messages for each null case
       if buffer.Capacity < HEADER_SIZE + CHECKSUM_SIZE then
          output := null;
       else
-         Get_Int32_t(buffer, ctrlStr);
+         Get_Int32(buffer, ctrlStr);
          if ctrlStr /= LMCP_CONTROL_STR then
             output := null;
          else
-            Get_UInt32_t(buffer, msgSize);
+            Get_UInt32(buffer, msgSize);
             if buffer.Capacity < msgSize then
                output := null;
             elsif(validate(buffer) = False) then
@@ -60,9 +60,9 @@ package body -<full_series_name_dots>-.factory is
                if(msgExists = False) then
                   output := null;
                else
-                  Get_Int64_t(buffer, seriesId);
-                  Get_UInt32_t(buffer, msgType);
-                  Get_UInt16_t(buffer, version);
+                  Get_Int64(buffer, seriesId);
+                  Get_UInt32(buffer, msgType);
+                  Get_UInt16(buffer, version);
                   output := createObject(seriesId, msgType, version);
                   if (output /= null) then
                      unpack(buffer, output);
@@ -73,7 +73,7 @@ package body -<full_series_name_dots>-.factory is
       end if;
    end getObject;
 
-   function createObject(seriesId : in Int64_t; msgType : in UInt32_t; version: in UInt16_t) return avtas.lmcp.object.Object_Any is
+   function createObject(seriesId : in Int64; msgType : in UInt32; version: in UInt16) return avtas.lmcp.object.Object_Any is
    begin
       if seriesId = 4849604199710720000 and then version = 3 then
          case msgType is
@@ -144,31 +144,31 @@ package body -<full_series_name_dots>-.factory is
       end if;
    end createObject;
 
-   function calculateChecksum (buffer : in ByteBuffer) return UInt32_t is
-      sum : UInt32_t := 0;
-      function IntToByteArray is new Ada.Unchecked_Conversion(Source => UInt32_t, Target => ByteArray4);
-      function ByteArrayToInt is new Ada.Unchecked_Conversion(Source => ByteArray4, Target => UInt32_t);
+   function calculateChecksum (buffer : in ByteBuffer) return UInt32 is
+      sum : UInt32 := 0;
+      function IntToByteArray is new Ada.Unchecked_Conversion(Source => UInt32, Target => ByteArray4);
+      function ByteArrayToInt is new Ada.Unchecked_Conversion(Source => ByteArray4, Target => UInt32);
    begin
       for i in 1 .. buffer.Capacity - CHECKSUM_SIZE loop
-         sum := sum + UInt32_t(buffer.Buf(i));
+         sum := sum + UInt32(buffer.Buf(i));
       end loop;
       -- The C++ code does the following, but why? It seems like a no-op to me
       -- Can't we just return sum?
-      -- return (ByteArrayToInt(IntToByteArray(sum) & IntToByteArray(UInt32_t(16#FFFFFFFF#))));
+      -- return (ByteArrayToInt(IntToByteArray(sum) & IntToByteArray(UInt32(16#FFFFFFFF#))));
       return sum;
    end calculateChecksum;
 
-   function getObjectSize (buffer : in ByteBuffer) return UInt32_t is
-      function ByteArrayToInt is new Ada.Unchecked_Conversion(Source => ByteArray4, Target => UInt32_t);
+   function getObjectSize (buffer : in ByteBuffer) return UInt32 is
+      function ByteArrayToInt is new Ada.Unchecked_Conversion(Source => ByteArray4, Target => UInt32);
    begin
       return ByteArrayToInt(buffer.Buf(5 .. 8));
    end getObjectSize;
 
    function validate(buffer : in ByteBuffer) return Boolean is
-      function ByteArrayToInt is new Ada.Unchecked_Conversion(Source => ByteArray4, Target => UInt32_t);
+      function ByteArrayToInt is new Ada.Unchecked_Conversion(Source => ByteArray4, Target => UInt32);
       subtype SwapType is ByteArray4;
       function SwapBytes is new GNAT.Byte_Swapping.Swapped4 (swapType);
-      sum : UInt32_t;
+      sum : UInt32;
    begin
       sum := calculateChecksum(buffer);
       return sum = 0 or else sum = ByteArrayToInt(SwapBytes(buffer.Buf(buffer.Buf'Last - 3 .. buffer.Buf'Last)));

--- a/src/templates/ada/mdm-factory.ads
+++ b/src/templates/ada/mdm-factory.ads
@@ -5,16 +5,16 @@ with avtas.lmcp.types; use avtas.lmcp.types;
 
 package -<full_series_name_dots>-.factory is
 
-   HEADER_SIZE : constant UInt32_t := 8;
-   CHECKSUM_SIZE : constant UInt32_t := 4;
-   SERIESNAME_SIZE : constant UInt32_t := 8;
-   LMCP_CONTROL_STR : constant Int32_t := 16#4c4d4350#;
+   HEADER_SIZE : constant UInt32 := 8;
+   CHECKSUM_SIZE : constant UInt32 := 4;
+   SERIESNAME_SIZE : constant UInt32 := 8;
+   LMCP_CONTROL_STR : constant Int32 := 16#4c4d4350#;
    
    function packMessage(rootObject : in avtas.lmcp.object.Object_Any; enableChecksum : in Boolean) return ByteBuffer;
    procedure getObject(buffer : in out ByteBuffer; output : out avtas.lmcp.object.Object_Any);
-   function createObject(seriesId : in Int64_t;  msgType : in UInt32_t; version: in UInt16_t) return avtas.lmcp.object.Object_Any;
-   function calculateChecksum(buffer : in ByteBuffer) return UInt32_t;
-   function getObjectSize(buffer : in ByteBuffer) return UInt32_t;
+   function createObject(seriesId : in Int64;  msgType : in UInt32; version: in UInt16) return avtas.lmcp.object.Object_Any;
+   function calculateChecksum(buffer : in ByteBuffer) return UInt32;
+   function getObjectSize(buffer : in ByteBuffer) return UInt32;
    function validate(buffer : in ByteBuffer) return Boolean;
 
 end -<full_series_name_dots>-.factory;

--- a/src/templates/ada/mdm-object.ads
+++ b/src/templates/ada/mdm-object.ads
@@ -9,9 +9,9 @@ package -<full_series_name_dots>-.object is
    type Object_Acc is access all Object;
    type Object_Any is access all Object'Class;
    
-   function getSeriesVersion(this : Object) return UInt16_t is (-<series_version>-);
+   function getSeriesVersion(this : Object) return UInt16 is (-<series_version>-);
    function getSeriesName(this : Object) return String is ("-<series_name>-");
-   function getSeriesNameAsLong(this : Object) return Int64_t is (-<series_id>-);
+   function getSeriesNameAsLong(this : Object) return Int64 is (-<series_id>-);
 
    procedure pack(this: in Object_Any; buf: in out ByteBuffer);
    procedure unpack(buf: in out ByteBuffer; this: in out Object_Any);

--- a/src/templates/ada/series_object.ads
+++ b/src/templates/ada/series_object.ads
@@ -18,10 +18,10 @@ package -<full_series_name_dots>-.-<datatype_name>- is
 
    function getFullLmcpTypeName(this : -<datatype_name>-) return String is ("-<full_datatype_name_dots>-");
    function getLmcpTypeName(this : -<datatype_name>-) return String is ("-<datatype_name>-");
-   function getLmcpType(this : -<datatype_name>-) return UInt32_t is (-<series_name>-Enum'Pos(-<datatype_name_caps>-_ENUM)+1);
+   function getLmcpType(this : -<datatype_name>-) return UInt32 is (-<series_name>-Enum'Pos(-<datatype_name_caps>-_ENUM)+1);
 
    -<get_and_set_methods_spec>-
-   function calculatePackedSize(this: -<datatype_name>-) return UInt32_t;
+   function calculatePackedSize(this: -<datatype_name>-) return UInt32;
 
    procedure pack(object_acc : in -<datatype_name>-_-<access_suffix>-; buf : in out ByteBuffer);
    procedure unpack(buf : in out ByteBuffer; object_acc : in out -<datatype_name>-_-<access_suffix>-);


### PR DESCRIPTION
The words "task" and "record" are prepended with "lmcp" so that they can appear as legal names in generated Ada code.
Change primitive type naming scheme to match those in the LmcpGen doc.