### PR TITLE
Enhancements to Ada Code Generation

### DIFF
--- a/src/templates/ada/avtas/avtas.ads
+++ b/src/templates/ada/avtas/avtas.ads
@@ -1,3 +1,3 @@
-package avtas is
+package AVTAS is
 
-end avtas;
+end AVTAS;

--- a/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers.adb
+++ b/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers.adb
@@ -50,6 +50,7 @@ package body AVTAS.LMCP.ByteBuffers is
    function Space_Available (This : ByteBuffer) return UInt32 is
       (if This.Position > This.Capacity then 0
        else This.Capacity - This.Position + 1);
+   -- NB: we need to prove no wraparound; the if-statement may suffice...
 
    -------------------------
    -- Msg_Bytes_Remaining --

--- a/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers.adb
+++ b/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers.adb
@@ -48,7 +48,8 @@ package body AVTAS.LMCP.ByteBuffers is
    ---------------------
 
    function Space_Available (This : ByteBuffer) return UInt32 is
-      (This.Capacity - This.Position + 1);
+      (if This.Position > This.Capacity then 0
+       else This.Capacity - This.Position + 1);
 
    -------------------------
    -- Msg_Bytes_Remaining --
@@ -256,7 +257,7 @@ package body AVTAS.LMCP.ByteBuffers is
       Result := MemCopy (Destination => This.Content (This.Position)'Address,
                          Source      => Source,
                          Count       => Storage_Count (Count));
-      This.Position := This.Position + Index (Count);
+      This.Position := This.Position + Count;
       This.Total_Bytes_Used := This.Total_Bytes_Used + Count;
    end Insert_Arbitrary_Bytes;
 
@@ -619,9 +620,9 @@ package body AVTAS.LMCP.ByteBuffers is
       This.Total_Bytes_Used := This.Total_Bytes_Used + 8;
    end Put_UInt64;
 
-   ---------------
+   ----------------
    -- Put_Real32 --
-   ---------------
+   ----------------
 
    procedure Put_Real32 (This : in out ByteBuffer; Value : Real32) is
    begin
@@ -647,8 +648,14 @@ package body AVTAS.LMCP.ByteBuffers is
 
    procedure Put_String (This : in out ByteBuffer;  Value : String) is
    begin
+      --  We need to put the length in any case, including when zero, so that
+      --  the deserialization routine will have a length to read. That routine
+      --  will then read that many bytes, so a zero length will work on that
+      --  side.
       This.Put_UInt16 (Value'Length);
-      This.Put_Raw_Bytes (Value);
+      if Value'Length > 0 then
+         This.Put_Raw_Bytes (Value);
+      end if;
    end Put_String;
 
    -------------------

--- a/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers.ads
+++ b/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers.ads
@@ -103,7 +103,7 @@ package AVTAS.LMCP.ByteBuffers is
                    Length (This) = Length (This)'Old and
                    Msg_Bytes_Remaining (This) = Msg_Bytes_Remaining (This)'Old;
    --  Gets a UInt32 value from This buffer, at indexes First .. First + 3
-   --  rather than from This.Position .. This.Positon + 3
+   --  rather than from This.Position .. This.Position + 3
 
    procedure Get_UInt32 (This : in out ByteBuffer;  Value : out UInt32) with
      Pre'Class  => Msg_Bytes_Remaining (This) >= 4,

--- a/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers.ads
+++ b/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers.ads
@@ -327,11 +327,11 @@ package AVTAS.LMCP.ByteBuffers is
 
    function Checksum (This : ByteBuffer;  From, To : Index) return UInt32 with
      Pre'Class =>
-       From <= To                and   -- only useful ranges
-       From <= This.Capacity     and   -- physically possible
-       To   <= This.Capacity     and   --     "         "
-       From <= This.Length       and   -- logically possible
-       To   <= This.Length;            --     "        "
+       From <= To             and   -- only useful ranges
+       From <= This.Capacity  and   -- physically possible
+       To   <= This.Capacity  and   --     "         "
+       From <= This.Length    and   -- logically possible
+       To   <= This.Length;         --     "        "
    --  Computes the checksum of the slice of the internal byte array From .. To.
 
 private

--- a/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers.ads
+++ b/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers.ads
@@ -300,7 +300,7 @@ package AVTAS.LMCP.ByteBuffers is
    --  and reading back out meaningful objects. The input Value is a String
    --  because that's the most convenient choice, based on client usage.
    --
-   --  NB: these routines dosn't write the length into the buffer because
+   --  NB: these routines don't write the length into the buffer because
    --  the content of the input string is an encoded (serialized) message
    --  already. That also means that there is no two-byte length restriction.
 

--- a/src/templates/ada/avtas/lmcp/avtas-lmcp-factory.adb
+++ b/src/templates/ada/avtas/lmcp/avtas-lmcp-factory.adb
@@ -1,7 +1,7 @@
 -<include_all_factories>-
 with Ada.Unchecked_Conversion;
 
-package body avtas.lmcp.factory is
+package body AVTAS.LMCP.Factory is
 
    function PackMessage (RootObject : in Avtas.Lmcp.Object.Object_Any; EnableChecksum : in Boolean) return ByteBuffer is
       -- Allocate space for message, with 15 extra bytes for
@@ -99,5 +99,5 @@ package body avtas.lmcp.factory is
       end if;
    end Validate;
 
-end avtas.lmcp.factory;
+end AVTAS.LMCP.Factory;
 

--- a/src/templates/ada/avtas/lmcp/avtas-lmcp-factory.ads
+++ b/src/templates/ada/avtas/lmcp/avtas-lmcp-factory.ads
@@ -1,8 +1,8 @@
-with avtas.lmcp.types;       use avtas.lmcp.types;
-with avtas.lmcp.byteBuffers; use avtas.lmcp.byteBuffers;
-with avtas.lmcp.object;      use avtas.lmcp.object;
+with AVTAS.LMCP.Types;       use AVTAS.LMCP.Types;
+with AVTAS.LMCP.ByteBuffers; use AVTAS.LMCP.ByteBuffers;
+with AVTAS.LMCP.Object;      use AVTAS.LMCP.Object;
 
-package avtas.lmcp.factory is
+package AVTAS.LMCP.Factory is
 
    HEADER_SIZE      : constant UInt32 := 8;
    CHECKSUM_SIZE    : constant UInt32 := 4;
@@ -25,4 +25,4 @@ package avtas.lmcp.factory is
    --  previously computed checksum value stored with the message
    --  in the buffer. Assumes the buffer is in Big Endian byte order.
 
-end avtas.lmcp.factory;
+end AVTAS.LMCP.Factory;

--- a/src/templates/ada/avtas/lmcp/avtas-lmcp-object.adb
+++ b/src/templates/ada/avtas/lmcp/avtas-lmcp-object.adb
@@ -1,4 +1,4 @@
-package body avtas.lmcp.object is
+package body AVTAS.LMCP.Object is
 
    procedure XML_Output (this  : Object'Class;
                          S     : access Ada.Streams.Root_Stream_Type'Class;
@@ -9,5 +9,5 @@ package body avtas.lmcp.object is
       String'Write (S, LeftPad ("</" & this.getLmcpTypeName & ">" & ASCII.LF, Level));
    end XML_Output;
 
-end avtas.lmcp.object;
+end AVTAS.LMCP.Object;
 

--- a/src/templates/ada/avtas/lmcp/avtas-lmcp-object.ads
+++ b/src/templates/ada/avtas/lmcp/avtas-lmcp-object.ads
@@ -1,9 +1,9 @@
-with avtas.lmcp.types; use avtas.lmcp.types;
-with avtas.lmcp.byteBuffers; use avtas.lmcp.byteBuffers;
+with AVTAS.LMCP.Types;       use AVTAS.LMCP.Types;
+with AVTAS.LMCP.ByteBuffers; use AVTAS.LMCP.ByteBuffers;
 with Ada.Streams;
 with Utilities;
 
-package avtas.lmcp.object is
+package AVTAS.LMCP.Object is
 
    type Object is abstract tagged null record;
    type Object_Acc is access all Object;
@@ -43,5 +43,5 @@ package avtas.lmcp.object is
                         S     : access Ada.Streams.Root_Stream_Type'Class;
                         Level : Natural) is null;
    
-end avtas.lmcp.object;
+end AVTAS.LMCP.Object;
 

--- a/src/templates/ada/avtas/lmcp/avtas-lmcp-types.ads
+++ b/src/templates/ada/avtas/lmcp/avtas-lmcp-types.ads
@@ -1,6 +1,6 @@
 with Interfaces; use Interfaces;
 
-package avtas.lmcp.types is
+package AVTAS.LMCP.Types is
 
    -- C/C++ compatible integer types
    type Byte   is new Interfaces.Unsigned_8;
@@ -13,4 +13,4 @@ package avtas.lmcp.types is
    type Real32 is new Interfaces.IEEE_Float_32;
    type Real64 is new Interfaces.IEEE_Float_64;
 
-end avtas.lmcp.types;
+end AVTAS.LMCP.Types;

--- a/src/templates/ada/avtas/lmcp/avtas-lmcp.ads
+++ b/src/templates/ada/avtas/lmcp/avtas-lmcp.ads
@@ -1,3 +1,3 @@
-package avtas.lmcp is
+package AVTAS.LMCP is
    
-end avtas.lmcp;
+end AVTAS.LMCP;

--- a/src/templates/ada/avtas/test_bytebuffers.adb
+++ b/src/templates/ada/avtas/test_bytebuffers.adb
@@ -21,7 +21,7 @@ begin
       Put_Line ("failed (should have raised Assertion_Error)");
    exception
       when Assertion_Error =>
-         Put_Line ("passed (raised Assertion_Error)");
+         Put_Line ("passed");
       when Error : others =>
          Put_Line (Exception_Information (Error));
    end;
@@ -50,7 +50,7 @@ begin
       Put_Line ("failed (should have raised Assertion_Error)");
    exception
       when Assertion_Error =>
-         Put_Line ("passed (raised Assertion_Error)");
+         Put_Line ("passed");
       when Error : others =>
          Put_Line (Exception_Information (Error));
    end;
@@ -89,7 +89,7 @@ begin
       Put_Line ("failed (should have raised Runtime_Length_Error)");
    exception
       when Runtime_Length_Error =>
-         Put_Line ("passed (raised Runtime_Length_Error)");
+         Put_Line ("passed");
       when Error : others =>
          Put_Line (Exception_Information (Error));
    end;
@@ -107,7 +107,7 @@ begin
       Put_Line ("failed (should have raised Assertion_Error)");
    exception
       when Assertion_Error =>
-         Put_Line ("passed (raised Assertion_Error)");
+         Put_Line ("passed");
       when Error : others =>
          Put_Line (Exception_Information (Error));
    end;
@@ -137,7 +137,39 @@ begin
       Put_Line ("failed (should have raised Assertion_Error)");
    exception
       when Assertion_Error =>
-         Put_Line ("passed (raised Assertion_Error)");
+         Put_Line ("passed");
+      when Error : others =>
+         Put_Line (Exception_Information (Error));
+   end;
+
+   declare
+      C : constant := 2;  -- the 2 bytes for the string's bounds
+      B : ByteBuffer (Capacity => C);
+      L : constant := 0;
+      S : constant Unbounded_String := To_Unbounded_String (Source => String'(1 .. L => 'x'));
+   begin
+      Put ("Inserting unbounded string with length = 0, with sufficient capacity ");
+      B.Put_Unbounded_String (S);
+      Put_Line ("passed");
+   exception
+      when Assertion_Error =>
+         Put_Line ("failed (raised Assertion_Error)");
+      when Error : others =>
+         Put_Line (Exception_Information (Error));
+   end;
+
+   declare
+      C : constant := 1;  -- less than the 2 bytes for the string's bounds
+      B : ByteBuffer (Capacity => C);
+      L : constant := 0;
+      S : constant Unbounded_String := To_Unbounded_String (Source => String'(1 .. L => 'x'));
+   begin
+      Put ("Inserting unbounded string with length = 0, without sufficient capacity ");
+      B.Put_Unbounded_String (S);
+      Put_Line ("failed");  -- we didn't have room for the bounds
+   exception
+      when Assertion_Error =>
+         Put_Line ("passed");
       when Error : others =>
          Put_Line (Exception_Information (Error));
    end;
@@ -168,7 +200,7 @@ begin
       Put_Line ("failed (should have raised Assertion_Error)");
    exception
       when Assertion_Error =>
-         Put_Line ("passed (raised Assertion_Error)");
+         Put_Line ("passed");
       when Error : others =>
          Put_Line (Exception_Information (Error));
    end;

--- a/src/templates/ada/enumerations.ads
+++ b/src/templates/ada/enumerations.ads
@@ -1,6 +1,6 @@
-package -<full_series_name_dots>-.enumerations is
+package -<full_series_name_dots>-.Enumerations is
    -<list_all_enumeration_types>-
    type -<series_name>-Enum is (
                      -<list_all_message_enumeration_names>-   );
 
-end -<full_series_name_dots>-.enumerations;
+end -<full_series_name_dots>-.Enumerations;

--- a/src/templates/ada/mdm-factory.adb
+++ b/src/templates/ada/mdm-factory.adb
@@ -1,7 +1,7 @@
 -<include_all_series_headers>-
 with Ada.Unchecked_Conversion;
 
-package body -<full_series_name_dots>-.factory is
+package body -<full_series_name_dots>-.Factory is
 
    procedure PutObject (Object : in Avtas.Lmcp.Object.Object_Any; Buffer : in out ByteBuffer);
    
@@ -105,5 +105,5 @@ package body -<full_series_name_dots>-.factory is
       end if;
    end Validate;
 
-end -<full_series_name_dots>-.factory;
+end -<full_series_name_dots>-.Factory;
 

--- a/src/templates/ada/mdm-factory.ads
+++ b/src/templates/ada/mdm-factory.ads
@@ -1,6 +1,6 @@
-with avtas.lmcp.byteBuffers;  use avtas.lmcp.byteBuffers;
+with AVTAS.LMCP.ByteBuffers;  use AVTAS.LMCP.ByteBuffers;
 
-package -<full_series_name_dots>-.factory is
+package -<full_series_name_dots>-.Factory is
 
    HEADER_SIZE      : constant := 8;
    CHECKSUM_SIZE    : constant := 4;
@@ -26,5 +26,5 @@ package -<full_series_name_dots>-.factory is
    --  previously computed checksum value stored with the message
    --  in the buffer. Assumes the buffer is in Big Endian byte order.
 
-end -<full_series_name_dots>-.factory;
+end -<full_series_name_dots>-.Factory;
 

--- a/src/templates/ada/mdm-object.adb
+++ b/src/templates/ada/mdm-object.adb
@@ -1,4 +1,4 @@
-package body -<full_series_name_dots>-.object is
+package body -<full_series_name_dots>-.Object is
 
    procedure pack (this: in Object_Any; buf: in out ByteBuffer) is
    begin
@@ -10,4 +10,4 @@ package body -<full_series_name_dots>-.object is
       null;
    end unpack;
 
-end -<full_series_name_dots>-.object;
+end -<full_series_name_dots>-.Object;

--- a/src/templates/ada/mdm-object.ads
+++ b/src/templates/ada/mdm-object.ads
@@ -1,8 +1,8 @@
-with avtas.lmcp.byteBuffers; use avtas.lmcp.byteBuffers;
+with AVTAS.LMCP.ByteBuffers; use AVTAS.LMCP.ByteBuffers;
 
-package -<full_series_name_dots>-.object is
+package -<full_series_name_dots>-.Object is
 
-   type Object is abstract new avtas.lmcp.object.Object with private;
+   type Object is abstract new AVTAS.LMCP.Object.Object with private;
    type Object_Acc is access all Object;
    type Object_Any is access all Object'Class;
 
@@ -12,7 +12,7 @@ package -<full_series_name_dots>-.object is
 
  private
 
-   type Object is abstract new avtas.lmcp.object.Object with null record;
+   type Object is abstract new AVTAS.LMCP.Object.Object with null record;
 
-end -<full_series_name_dots>-.object;
+end -<full_series_name_dots>-.Object;
 


### PR DESCRIPTION
This pull request includes several fixes from AdaCore to improve the Ada code generation for LmcpGen. Most notably, we have introduced a static map to allow us to rename (change the case of) identifiers so that they are more consistent with the way in which identifiers are cased in Ada. This map could be externalized into a file in future updates as desired.

Note: this PR should be merged before an upcoming PR for OpenUxAS.