### PR TITLE
Update package ByteBuffers to simplify use of the overloaded Raw_Bytes functions, etc.

### DIFF
--- a/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers-copying.ads
+++ b/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers-copying.ads
@@ -36,8 +36,8 @@ is
                     To_String (Destination))                  and then
              Prior_Content_Unchanged (This, Old_Value => This'Old),
      Inline;
- 
- 
+
+
    procedure Copy_String_To_Buffer
      (This : in out ByteBuffer'Class;
       From : String)

--- a/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers.adb
+++ b/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers.adb
@@ -7,19 +7,19 @@ is
 
    pragma Unevaluated_Use_Of_Old (Allow);
 
-   ---------------
-   -- Raw_Bytes --
-   ---------------
+   -------------------------
+   -- Raw_Bytes_As_String --
+   -------------------------
 
-   function Raw_Bytes (This : ByteBuffer'Class) return String is
-      Length : constant Natural := Natural (Index'Min (Max_String_Length, This.Highest_Write_Pos));
+   function Raw_Bytes_As_String (This : ByteBuffer'Class) return String is
+      Length : constant Natural := Natural (This.Highest_Write_Pos);  -- safe due to precondition
       Result : String (1 .. Length);
    begin
       for K in Result'Range loop
          Result (K) := Character'Val (This.Content (Index (K - 1)));
       end loop;
       return Result;
-   end Raw_Bytes;
+   end Raw_Bytes_As_String;
 
    ------------
    -- Rewind --

--- a/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers.ads
+++ b/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers.ads
@@ -476,9 +476,7 @@ private
    ---------------
 
    function Raw_Bytes (This : ByteBuffer'Class) return Byte_Array is
-     (if This.Highest_Write_Pos > 0
-      then This.Content (0 .. This.Highest_Write_Pos - 1)
-      else This.Content (1 .. 0));
+      (This.Content (0 .. This.Highest_Write_Pos - 1));
 
    ---------------
    -- Remaining --

--- a/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers.ads
+++ b/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers.ads
@@ -41,8 +41,9 @@ is
    --  back to 0 by a call to Reset.
 
    procedure Rewind (This : in out ByteBuffer'Class) with
-     Post => Position (This) = 0 and
-             High_Water_Mark (This) = High_Water_Mark (This)'Old;
+     Post => Position (This) = 0                                 and then
+             High_Water_Mark (This) = High_Water_Mark (This)'Old and then
+             Raw_Bytes (This) = Raw_Bytes (This)'Old;
    --  Rewinding the buffer position allows reading of existing content from
    --  the beginning, presumably after writing values into it (via the Put_*
    --  routines).
@@ -101,12 +102,13 @@ is
       Value : out UInt32;
       First : Index)
    with
-     Pre  => First <= This.Capacity      and then
-             High_Water_Mark (This) >= First + 3,
-     Post => Position (This) = Position (This)'Old                         and then
-             High_Water_Mark (This) = High_Water_Mark (This)'Old           and then
-             Remaining (This) = Remaining (This)'Old                       and then
-             Raw_Bytes (This) = Raw_Bytes (This)'Old;
+     Pre  => First <= This.Capacity - 3 and then
+             First + 3 <= High_Water_Mark (This) - 1,
+     Post => Position (This) = Position (This)'Old               and then
+             High_Water_Mark (This) = High_Water_Mark (This)'Old and then
+             Remaining (This) = Remaining (This)'Old             and then
+             Raw_Bytes (This) = Raw_Bytes (This)'Old             and then
+             Raw_Bytes (This) (First .. First + 3) = As_Four_Bytes (Value);
    --  Gets the four bytes comprising a UInt32 value from This buffer, starting
    --  at absolute index First (rather than from This.Position)
 
@@ -175,7 +177,6 @@ is
        Position (This) <= High_Water_Mark (This) - 2,
        --  The string content is preceded in the buffer by a two-byte length,
        --  even when the string length is zero (ie when the string is empty).
-
      Post =>
        High_Water_Mark (This) = High_Water_Mark (This)'Old and then
        Stored_Length <= Max_String_Length                  and then
@@ -377,13 +378,13 @@ is
              Prior_Content_Unchanged (This, Old_Value => This'Old);
 
    function Raw_Bytes (This : ByteBuffer'Class) return Byte_Array;
-   --  Returns the internal byte array content, up to High_Water_Mark (This)
+   --  Returns the entire internal byte array content, up to High_Water_Mark (This)
 
-   function Raw_Bytes (This : ByteBuffer'Class) return String with
-     Post => Raw_Bytes'Result'First = 1 and then
-             Raw_Bytes'Result'Length = Index'Min (Max_String_Length, High_Water_Mark (This));
-   --  Returns the internal byte array content, up to High_Water_Mark (This),
-   --  as a String
+   function Raw_Bytes_As_String (This : ByteBuffer'Class) return String with
+     Pre  => High_Water_Mark (This) <= Index (Positive'Last),
+     Post => Raw_Bytes_As_String'Result'First = 1 and then
+             Raw_Bytes_As_String'Result'Length = High_Water_Mark (This);
+   --  Returns the entire internal byte array content, as a String
 
    function Checksum (This : ByteBuffer'Class;  Last : Index) return UInt32 with
      Pre => Last <= This.Capacity;

--- a/src/templates/ada/avtas/lmcp/prove_bytebuffers.adb
+++ b/src/templates/ada/avtas/lmcp/prove_bytebuffers.adb
@@ -1,0 +1,333 @@
+with AVTAS.LMCP.ByteBuffers; use AVTAS.LMCP.ByteBuffers;
+with Ada.Text_IO;            use Ada.Text_IO;
+with Ada.Assertions;         use Ada.Assertions;
+with Ada.Strings.Unbounded;
+with AVTAS.LMCP.Types;       use AVTAS.LMCP.Types;
+with Ada.Unchecked_Deallocation;
+
+procedure Prove_ByteBuffers with
+   SPARK_Mode
+is
+   package ASU renames Ada.Strings.Unbounded;
+begin
+
+   pragma Warnings (Off, "has no effect");
+   pragma Warnings (Off, "not used after the call");
+
+--  get from relative index after rewind -------------------------------------
+
+   declare
+      C : constant := 100; -- arbitrary
+      B : ByteBuffer (Capacity => C);
+      V : UInt16;
+   begin
+      Put_Line ("Get (first) value after rewind");
+      B.Put_Uint16 (42);
+      B.Rewind;
+      B.Get_UInt16 (V);
+      pragma Assert (V = 42);
+   end;
+
+--  get from absolute index --------------------------------------------------
+
+   declare
+      --                                  123456789ABC
+      String_Input  : constant String := "Hello World!";
+      Index_After_String : constant := 2 + String_Input'Length;
+      --  the 2-byte length of the string precedes the actual string content so
+      --  we add 2
+
+      UInt32_Input  : constant UInt32 := 42;
+      Byte_Input    : constant Byte := 42;
+
+      Expected_High_Water_Mark : constant := 2 + String_Input'Length + 4 + 1;
+      --  2-bytes for string length + length of string + 4 bytes for uint32 + 1 byte for boolean
+
+      Buffer : ByteBuffer (Capacity => 100);
+   begin
+      Put_Line ("Get_UInt32 from absolute index > position and <= high water mark");
+      Buffer.Put_String (String_Input);
+      Buffer.Put_UInt32 (UInt32_Input);
+      Buffer.Put_Byte (Byte_Input);
+
+      Buffer.Rewind;
+
+      Assert (Position (Buffer) = 0);
+      Assert (High_Water_Mark (Buffer) = Expected_High_Water_Mark);
+
+      --  now we read back one of the written values at an absolute position
+      --  that is greater than the current position but not greater than the
+      --  high water mark, which should succeed
+      declare
+         Output : UInt32;
+      begin
+         Buffer.Get_UInt32 (Output, First => Index_After_String);
+         pragma Assert (Output = UInt32_Input);
+      end;
+   end;
+
+--  inserting strings --------------------------------------------------------
+
+   declare
+      C : constant := 100; -- arbitrary
+      B : ByteBuffer (Capacity => C);
+      L : constant := C - 2;  -- leave room for length inserted into buffer too
+      S : constant String (1 .. L) := (others => 'x');
+   begin
+      Put_Line ("Inserting string with length < capacity");
+      B.Put_String (S);
+   end;
+
+   declare
+      C : constant := UInt16'Last;
+      B : ByteBuffer (Capacity => C + 2);
+      S : constant String (1 .. Integer (UInt16'Last)) := (others => 'x');
+   begin
+      Put_Line ("Inserting string with length = UInt16'Last, with sufficient capacity");
+      B.Put_String (S);
+   end;
+
+--  getting Strings ----------------------------------------------------------
+
+   declare
+      C : constant := 100; -- arbitrary
+      B : ByteBuffer (Capacity => C);
+      Corrupted_String_Length : constant := C + 1; -- anything > C will do
+      S : String (1 .. Corrupted_String_Length) := (others => ' ');
+      Last : Integer;
+      Unused : UInt32;
+   begin
+      Put_Line ("Getting string with stored length > remaining bytes in message");
+      --  Write a value that Get_String is going to read as the length of the
+      --  string in the message. The value must be > buffer capacity.
+      B.Put_UInt16 (Corrupted_String_Length);
+      --  Prepare to start getting values as if a message is in the buffer,
+      --  starting with a string. The actual characters are immaterial so we
+      --  don't bother to insert them into the buffer.
+      --
+      --  Note that this wouldn't happen without some sort of buffer
+      --  corruption because Put_String would have failed when attempting to
+      --  write that any chars into the buffer (since we know the buffer isn't
+      --  big enough in this test, on purpose).
+
+      B.Rewind;
+      B.Get_String (S, Last, Unused);
+      pragma Assert (B.Position = 2);
+      pragma Assert (Last = -1);
+   end;
+
+   -- the case in which stored length > string arg length AND we just set Last to -1
+   declare
+      C : constant := 10; -- arbitrary
+      B : ByteBuffer (Capacity => C);
+      Written : constant String (1 .. 8) := "helloyou";
+      Read : String (1 .. 5) := (others => ' ');
+      Last : Integer;
+      Stored_Length : UInt32;
+   begin
+      Put_Line ("Getting string with stored length > arg length");
+      B.Put_String (Written);
+      B.Rewind;
+      B.Get_String (Read, Last, Stored_Length);
+
+      pragma Assert (Last = -1);
+      pragma Assert (B.Position = 2);
+   end;
+
+   declare
+      C : constant := 100; -- arbitrary
+      B : ByteBuffer (Capacity => C);
+      Written : constant String (1 .. 5) := "world";
+      Read : String (1 .. 10) := (others => ' ');
+      Last : Integer;
+      Unused : UInt32;
+   begin
+      Put_Line ("Getting string with stored length < arg length");
+      B.Put_String (Written);
+      --  prepare to start getting values as if a message is in the buffer,
+      --  starting with a string
+      B.Rewind;
+      B.Get_String (Read, Last, Unused);
+      pragma Assert (Last = Written'Length);
+      pragma Assert (Read (1 .. Last) = Written);
+   end;
+
+--  writing unbounded strings -------------------------------------------------
+
+   declare
+      C : constant := 100; -- arbitrary
+      L : constant := C - 2;  -- leave room for length inserted into buffer too
+      B : ByteBuffer (Capacity => C);
+      S : constant ASU.Unbounded_String := ASU.To_Unbounded_String (Source => String'(1 .. L => 'x'));
+   begin
+      Put_Line ("Inserting unbounded string with length < capacity");
+      B.Put_Unbounded_String (S);
+   end;
+
+   declare
+      C : constant := 2;  -- the 2 bytes for the string's bounds
+      B : ByteBuffer (Capacity => C);
+      L : constant := 0;
+      S : constant ASU.Unbounded_String := ASU.To_Unbounded_String (Source => String'(1 .. L => 'x'));
+   begin
+      Put_Line ("Inserting unbounded string with length = 0, with sufficient capacity");
+      B.Put_Unbounded_String (S);
+   end;
+
+   declare
+      C : constant := 100; -- arbitrary
+      L : constant := C - 2;  -- leave room for length inserted into buffer too
+      B : ByteBuffer (Capacity => C);
+      S : constant ASU.Unbounded_String := ASU.To_Unbounded_String (Source => String'(1 .. L => 'x'));
+   begin
+      Put_Line ("Inserting unbounded string with length < capacity");
+      B.Put_Unbounded_String (S);
+   end;
+
+--  reading unbounded strings -------------------------------------------------
+
+   declare
+      C : constant := Max_String_Length;
+      B : ByteBuffer (Capacity => C + 2);
+      L : constant := Integer (C);
+      S : constant ASU.Unbounded_String := ASU.To_Unbounded_String (Source => String'(1 .. L => 'x'));
+      O : ASU.Unbounded_String := ASU.To_Unbounded_String (Length => L);
+      Num_Stored : UInt32;
+      use ASU;
+   begin
+      Put_Line ("Getting unbounded string with length = Max_String_Length, with sufficient capacity");
+      B.Put_Unbounded_String (S);
+      B.Rewind;
+      B.Get_Unbounded_String (O, Num_Stored);
+      pragma Assert (Num_Stored = Max_String_Length);
+      pragma Assert (O = S);
+   end;
+
+--  raw bytes ----------------------------------------------------------------
+
+   declare
+      C : constant := 100; -- arbitrary
+      B : ByteBuffer (Capacity => C);
+      L : constant := C - 2;  -- leave room for length inserted into buffer too
+      S : constant String (1 .. L) := (others => 'x');
+   begin
+      Put_Line ("Inserting raw bytes from String with length < capacity");
+      B.Put_Raw_Bytes (S);
+   end;
+
+   declare
+      C : constant := 100; -- arbitrary
+      B : ByteBuffer (Capacity => C);
+      L : constant := C - 2;  -- leave room for length inserted into buffer too
+      S : constant Byte_Array (1 .. L) := (others => Character'Pos ('x'));
+   begin
+      Put_Line ("Inserting raw bytes with length < capacity");
+      B.Put_Raw_Bytes (S);
+   end;
+
+   declare
+      C : constant := UInt32 (Positive'Last) + 10;
+      type ByteBuffer_Pointer is access ByteBuffer;
+      BBP : ByteBuffer_Pointer := new ByteBuffer (C);
+
+      L : constant := Positive'Last;
+      subtype Constrained_Byte_Array is Byte_Array (1 .. L);
+      type Byte_Array_Pointer is access Constrained_Byte_Array;
+      BAP : Byte_Array_Pointer := new Byte_Array'(1 .. L => Character'Pos ('x'));
+
+      procedure Free is new Ada.Unchecked_Deallocation
+        (Object => ByteBuffer, Name => ByteBuffer_Pointer);
+      procedure Free is new Ada.Unchecked_Deallocation
+        (Object => Constrained_Byte_Array, Name => Byte_Array_Pointer);
+   begin
+      Put_Line ("Inserting raw bytes with length = Positive'Last");
+      BBP.Put_Raw_Bytes (BAP.all);
+      --  and free them to keep SPARK happy
+      Free (BAP);
+      Free (BBP);
+   end;
+
+--  sequence of writes followed by sequence of reads  ------------------------
+
+   declare
+      Byte_Input    : constant Byte := 42;
+      String_Input  : constant String := "Hello World!";
+      UInt32_Input  : constant UInt32 := 42;
+      Real32_Input  : constant Real32 := 42.42;
+      Boolean_Input : constant Boolean := True;
+      UInt64_Input  : constant UInt64 := 84;
+
+      Buffer : ByteBuffer (Capacity => 1024);
+   begin
+      Put_Line ("Multiple writes folowed by reads of those written values");
+
+      --  NB: the order of the following must match the order of the calls to Get_* below
+      Buffer.Put_Byte (Byte_Input);
+      Buffer.Put_String (String_Input);
+      Buffer.Put_UInt32 (UInt32_Input);
+      Buffer.Put_Unbounded_String (ASU.To_Unbounded_String (String_Input));
+      Buffer.Put_Real32 (Real32_Input);
+      Buffer.Put_Boolean (Boolean_Input);
+      Buffer.Put_UInt64 (UInt64_Input);
+
+      --  now we read back what was written
+
+      Buffer.Rewind;
+
+      declare
+         Output : Byte;
+      begin
+         Buffer.Get_Byte (Output);
+         pragma Assert (Output = Byte_Input);
+      end;
+
+      declare
+         Output : String (String_Input'Range) := (others => ' ');
+         Last   : Integer;  -- because result can be -1 to signal a problem
+         Unused : UInt32;
+      begin
+         Buffer.Get_String (Output, Last, Unused);
+         pragma Assert (Last = String_Input'Length);
+         pragma Assert (Output (1 .. Last) = String_Input);
+      end;
+
+      declare
+         Output : UInt32;
+      begin
+         Buffer.Get_UInt32 (Output);
+         pragma Assert (Output = UInt32_Input);
+      end;
+
+      declare
+         Output : ASU.Unbounded_String;
+         Num_Stored : UInt32;
+      begin
+         Buffer.Get_Unbounded_String (Output, Num_Stored);
+         pragma Assert (Num_Stored = String_Input'Length);
+         pragma Assert (ASU.To_String (Output) = String_Input);
+      end;
+
+      declare
+         Output : Real32;
+      begin
+         Buffer.Get_Real32 (Output);
+         pragma Assert (Output = Real32_Input);
+      end;
+
+      declare
+         Output : Boolean;
+      begin
+         Buffer.Get_Boolean (Output);
+         pragma Assert (Output = Boolean_Input);
+      end;
+
+      declare
+         Output : UInt64;
+      begin
+         Buffer.Get_UInt64 (Output);
+         pragma Assert (Output = UInt64_Input);
+      end;
+   end;
+
+   Put_Line ("Done");  -- just in case you actually want to run this
+end Prove_ByteBuffers;

--- a/src/templates/ada/avtas/lmcp/test_bytebuffers.adb
+++ b/src/templates/ada/avtas/lmcp/test_bytebuffers.adb
@@ -18,7 +18,7 @@ begin
       B : ByteBuffer (Capacity => C);
       V : UInt16 := 42;
    begin
-      Put ("Get UInt16 at absolute index: ");
+      Put ("Get (first) value after rewind: ");
       B.Put_Uint16 (V);
       B.Rewind;
       V := 0;

--- a/src/templates/ada/avtas/test_bytebuffers.gpr
+++ b/src/templates/ada/avtas/test_bytebuffers.gpr
@@ -2,7 +2,7 @@ project Test_ByteBuffers is
 
    for Source_Dirs use (".", "lmcp");
 
-   for Main use ("test_bytebuffers.adb");
+   for Main use ("prove_bytebuffers.adb", "test_bytebuffers.adb");
 
    type Modes is ("debug", "release");
    Mode : Modes := external ("Build", "debug");


### PR DESCRIPTION
Correct a design flaw in the Raw_Bytes function returning a String value, in which the body truncated the result at Max_String_Length if the buffer content was larger than that. That result works correctly with the specific OpenUxAS application code because the app never exceeds strings of that maximum length, but in general it could omit existing buffer content. The function's resulting String value is unconstrained and is meant to contain the entire buffer content. Hence the function now returns the entire content, with a new precondition verifying that the complete content is not physically larger than the maximum possible Ada String (index) length.

Change the name of the function Raw_Bytes returning a String value (the one described above) so that it is no longer overloaded with the function that returns a Byte_Array value. The new function name is Raw_Bytes_As_String. Prior to the name change, the only difference in the functions' profiles was the result type, i.e., the names and parameters were identical. Calls to such functions are disambiguated by the expected result type, but some call contexts in the ByteBuffers package itself were ambiguous. In particular, the function returning the Byte_Array value is used by the application code but also serves as the "model" for the ByteBuffer type and therefore appears in some of the routines' postconditions.

Correct a minor error in an output string in the functional test program Test_ByteBuffers.

Create an additional client main procedure used for verifying client usage of the ByteBuffers ADT. This main procedure, Prove_ByteBuffers, is SPARK compliant, unlike Test_ByteBuffers. Because it is intended to prove only successful client use-cases, it contains a subset of the checks in Test_ByteBufers.  _Note that not all assertions in this client main procedure will prove successfully in this initial version._ The first purpose of this procedure is to verify that calls to the ByteBuffer routines themselves are provable. Later, we intend to be able to prove the assertions about client usage, which is largely a matter of sufficient postconditions for the routines.

Add the new main procedure Prove_ByteBuffers to the project GPR file, as the default main. As the default, the SPARK-compliant Prove_ByteBuffers procedure will be analyzed when we tell gnatprove to prove all the files.

Remove extraneous blanks in file avtas-lmcp-bytebuffers-copying.ads.