### PR TITLE
fix error in precondition, strengthen code, subsume PR #35

### DIFF
--- a/src/templates/ada/avtas/lmcp/a-strunb.adb
+++ b/src/templates/ada/avtas/lmcp/a-strunb.adb
@@ -6,7 +6,7 @@
 --                                                                          --
 --                                 B o d y                                  --
 --                                                                          --
---          Copyright (C) 1992-2021, Free Software Foundation, Inc.         --
+--          Copyright (C) 1992-2022, Free Software Foundation, Inc.         --
 --                                                                          --
 -- GNAT is free software;  you can  redistribute it  and/or modify it under --
 -- terms of the  GNU General Public License as published  by the Free Soft- --

--- a/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers-copying-performant_adb
+++ b/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers-copying-performant_adb
@@ -1,55 +1,75 @@
 with System.Storage_Elements;  use System.Storage_Elements;
 
 package body AVTAS.LMCP.ByteBuffers.Copying with
-   SPARK_Mode => Off
+   SPARK_Mode
 is
 
    -----------------
    -- Overlapping --
    -----------------
 
-   function Overlapping (Destination, Source : Address; Count : Storage_Count) return Boolean is
-     (for some Location in To_Integer (Destination) .. To_Integer (Destination + Count - 1) =>
-        Location in To_Integer (Source) .. To_Integer (Source + Count - 1))
-   with Pre => Source /= Null_Address and
-               Destination /= Null_Address;
+   function Overlapping (Block_1, Block_2 : Address; Count : Storage_Count) return Boolean is
+     (declare
+        Block_1_First : constant Integer_Address := To_Integer (Block_1);
+        Block_2_First : constant Integer_Address := To_Integer (Block_2);
+        Block_1_Last  : constant Integer_Address := To_Integer (Block_1 + Count - 1);
+        Block_2_Last  : constant Integer_Address := To_Integer (Block_2 + Count - 1);
+      begin
+        (for some Location in Block_1_First .. Block_1_Last =>
+           Location in Block_2_First .. Block_2_Last))
+   with
+      Pre => Block_2 /= Null_Address and
+             Block_1 /= Null_Address;
 
    -------------
    -- MemCopy --
    -------------
 
-   function MemCopy (Destination, Source : Address; Length : Storage_Count) return Address with
+   function MemCopy
+     (Destination      : Address;
+      Destination_Size : Storage_Count;
+      Source           : Address;
+      Count            : Storage_Count)
+   return Integer
+   with
      Inline,
      Import,
      Convention => C,
-     Link_Name => "memcpy",
-     Pre => Source /= Null_Address and then
-            Destination /= Null_Address and then
-            Source /= Destination and then  --- covered by Overlapping but aids comprehension
-            not Overlapping (Destination, Source, Length),
-     Post => MemCopy'Result = Destination;
+     Link_Name => "memcpy_s",
+     Pre  => Source /= Null_Address and then
+             Destination /= Null_Address and then
+             Destination_Size >= Count and then
+             not Overlapping (Destination, Source, Count),
+     Post => MemCopy'Result = 0;
    --  Copies Length bytes from the object designated by Source to the object
-   --  designated by Destination. Note the order of the address parameters is
-   --  critical so use the named association format for specifying actuals in
-   --  calls.
+   --  designated by Destination. Note the order of the address parameters
+   --  is critical so callers should use the named association format for
+   --  specifying actuals in calls.
+   --
+   --  If the result is non-zero but Destination and Destination_Size are
+   --  valid, the region starting at Destination, of Destination_Size bytes,
+   --  will be zeroed. However, the necessary causes of that failure are
+   --  precluded via the preconditions, so we don't check that in the
+   --  postcondition.
 
    ---------------------------
    -- Copy_Buffer_To_String --
    ---------------------------
-   
+
    procedure Copy_Buffer_To_String
      (This        : in out ByteBuffer'Class;
       Length      : Index;
       Destination : in out String)
    is
-      Result : System.Address with Unreferenced;
+      Result : Integer with Unreferenced;  -- checked by postcondition
    begin
-      Result := MemCopy (Source      => This.Content (This.Position)'Address,
-                         Destination => Destination'Address,
-                         Length      => Storage_Count (Length));
+      Result := MemCopy (Source           => This.Content (This.Position)'Address,
+                         Destination      => Destination'Address,
+                         Destination_Size => Destination'Length,
+                         Count            => Storage_Count (Length));
       This.Position := This.Position + Length;
-   end Copy_Buffer_To_String;   
-   
+   end Copy_Buffer_To_String;
+
    -------------------------------------
    -- Copy_Buffer_To_Unbounded_String --
    -------------------------------------
@@ -59,50 +79,52 @@ is
       Length      : Index;
       Destination : out Unbounded_String)
    is
-      Temp    : String (1 .. Integer (Length));
-      Old_Pos : constant Index := This.Position with Ghost;
-      Result  : System.Address with Unreferenced;
+      Buffer_As_String : String (1 .. Integer (Length));
+      Result           : Integer with Unreferenced;  -- checked by postcondition
    begin
-      Result := MemCopy (Source      => This.Content (This.Position)'Address,
-                         Destination => Temp'Address,
-                         Length      => Storage_Count (Length));
+      Result := MemCopy (Source           => This.Content (This.Position)'Address,
+                         Destination      => Buffer_As_String'Address,
+                         Destination_Size => Buffer_As_String'Length,
+                         Count            => Storage_Count (Length));
+      pragma Assert (Equal (Raw_Bytes (This) (This.Position .. This.Position + Length - 1), Buffer_As_String));
       This.Position := This.Position + Length;
-      pragma Assert (Equal (Raw_Bytes (This) (Old_Pos .. Position (This) - 1), Temp));
-      Destination := To_Unbounded_String (Temp);
-   end Copy_Buffer_To_Unbounded_String;   
-     
+      Destination := To_Unbounded_String (Buffer_As_String);
+   end Copy_Buffer_To_Unbounded_String;
+
    ---------------------------
    -- Copy_String_To_Buffer --
    ---------------------------
-   
+
    procedure Copy_String_To_Buffer
      (This : in out ByteBuffer'Class;
       From : String)
    is
-      Result : System.Address with Unreferenced;
+      Result : Integer with Unreferenced;  -- checked by postcondition
    begin
-      Result := MemCopy (Source      => From'Address,
-                         Destination => This.Content (This.Position)'Address,
-                         Length      => Storage_Count (From'Length));
+      Result := MemCopy (Source           => From'Address,
+                         Destination      => This.Content (This.Position)'Address,
+                         Destination_Size => Storage_Count (This.Capacity - This.Position + 1),
+                         Count            => Storage_Count (From'Length));
       This.Highest_Write_Pos := This.Highest_Write_Pos + From'Length;
       This.Position := This.Position + From'Length;
    end Copy_String_To_Buffer;
-   
+
    --------------------------
    -- Copy_Bytes_To_Buffer --
    --------------------------
-   
+
    procedure Copy_Bytes_To_Buffer
      (This : in out ByteBuffer'Class;
       From : Byte_Array)
    is
-      Result : System.Address with Unreferenced;
+      Result : Integer with Unreferenced;  -- checked by postcondition
    begin
-      Result := MemCopy (Source      => From'Address,
-                         Destination => This.Content (This.Position)'Address,
-                         Length      => Storage_Count (From'Length));
+      Result := MemCopy (Source           => From'Address,
+                         Destination      => This.Content (This.Position)'Address,
+                         Destination_Size => Storage_Count (This.Capacity - This.Position + 1),
+                         Count            => Storage_Count (From'Length));
       This.Highest_Write_Pos := This.Highest_Write_Pos + From'Length;
       This.Position := This.Position + From'Length;
    end Copy_Bytes_To_Buffer;
-   
+
 end AVTAS.LMCP.ByteBuffers.Copying;

--- a/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers-copying-provable_adb
+++ b/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers-copying-provable_adb
@@ -2,6 +2,8 @@ package body AVTAS.LMCP.ByteBuffers.Copying with
    SPARK_Mode
 is
 
+   package ASU renames Ada.Strings.Unbounded;
+
    ---------------------------
    -- Copy_Buffer_To_String --
    ---------------------------
@@ -17,8 +19,6 @@ is
          Destination (Destination'First + Integer (K)) := Character'Val (This.Content (This.Position));
 
          pragma Loop_Invariant (This.Position = This.Position'Loop_Entry + K);
-         pragma Loop_Invariant (This.Position <= This.Capacity - Length + K);
-         pragma Loop_Invariant (This.Position < This.Highest_Write_Pos);
          pragma Loop_Invariant
            (for all J in 0 .. K =>
               Destination (Destination'First + Integer (J)) = Character'Val (This.Content (Old_Pos + J)));
@@ -39,19 +39,15 @@ is
       Old_Pos : constant Index := Position (This) with Ghost;
    begin
       Destination := Null_Unbounded_String;
-      pragma Assume (Ada.Strings.Unbounded.Length (Destination) = 0);
+      pragma Assume (ASU.Length (Destination) = 0);
       for K in 0 .. Length - 1 loop
          Append (Destination, Character'Val (This.Content (This.Position)));
 
-         pragma Loop_Invariant (This.Position = Old_Pos + K);
-         pragma Loop_Invariant (This.Position <= This.Capacity - Length + K);
-         pragma Loop_Invariant (This.Position < This.Highest_Write_Pos);
-         pragma Loop_Invariant (Ada.Strings.Unbounded.Length (Destination) = Integer (K) + 1);
-         pragma Loop_Invariant (Ada.Strings.Unbounded.Length (Destination) < Natural'Last);
-         pragma Loop_Invariant (Ada.Strings.Unbounded.Length (Destination) <= Max_String_Length);
+         pragma Loop_Invariant (ASU.Length (Destination) = 1 + Integer (K));
          pragma Loop_Invariant
            (for all J in 0 .. K =>
               Element (Destination, 1 + Integer (J)) = Character'Val (This.Content (Old_Pos + J)));
+         pragma Loop_Invariant (This.Position = Old_Pos + K);
 
          This.Position := This.Position + 1;
       end loop;

--- a/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers-copying.ads
+++ b/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers-copying.ads
@@ -27,23 +27,22 @@ is
       Destination : out Unbounded_String)
    with
      Pre  => Remaining (This) >= Length  and then
-             Length <= Max_String_length and then
+             Length <= Index (Positive'Last) and then
              Position (This) + Length <= High_Water_Mark (This),
      Post => Position (This) = Position (This)'Old + Length      and then
              High_Water_Mark (This) = High_Water_Mark (This)'Old and then
              Remaining (This) = Remaining (This)'Old - Length    and then
              Equal (Raw_Bytes (This) (Position (This)'Old .. Position (This) - 1),
-                    To_String (Destination))                  and then
+                    To_String (Destination))                     and then
              Prior_Content_Unchanged (This, Old_Value => This'Old),
      Inline;
- 
- 
+
+
    procedure Copy_String_To_Buffer
      (This : in out ByteBuffer'Class;
       From : String)
    with
      Pre  => Remaining (This) >= From'Length  and then
-             From'Length <= Max_String_Length and then
              High_Water_Mark (This) + From'Length <= This.Capacity,
      Post => Position (This) = Position (This)'Old + From'Length               and then
              High_Water_Mark (This) = High_Water_Mark (This)'Old + From'Length and then

--- a/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers.adb
+++ b/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers.adb
@@ -7,19 +7,19 @@ is
 
    pragma Unevaluated_Use_Of_Old (Allow);
 
-   ---------------
-   -- Raw_Bytes --
-   ---------------
+   -------------------------
+   -- Raw_Bytes_As_String --
+   -------------------------
 
-   function Raw_Bytes (This : ByteBuffer'Class) return String is
-      Length : constant Natural := Natural (Index'Min (Max_String_Length, This.Highest_Write_Pos));
+   function Raw_Bytes_As_String (This : ByteBuffer'Class) return String is
+      Length : constant Natural := Natural (This.Highest_Write_Pos);  -- safe due to precondition
       Result : String (1 .. Length);
    begin
       for K in Result'Range loop
          Result (K) := Character'Val (This.Content (Index (K - 1)));
       end loop;
       return Result;
-   end Raw_Bytes;
+   end Raw_Bytes_As_String;
 
    ------------
    -- Rewind --

--- a/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers.ads
+++ b/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers.ads
@@ -41,8 +41,9 @@ is
    --  back to 0 by a call to Reset.
 
    procedure Rewind (This : in out ByteBuffer'Class) with
-     Post => Position (This) = 0 and
-             High_Water_Mark (This) = High_Water_Mark (This)'Old;
+     Post => Position (This) = 0                                 and then
+             High_Water_Mark (This) = High_Water_Mark (This)'Old and then
+             Raw_Bytes (This) = Raw_Bytes (This)'Old;
    --  Rewinding the buffer position allows reading of existing content from
    --  the beginning, presumably after writing values into it (via the Put_*
    --  routines).
@@ -101,12 +102,13 @@ is
       Value : out UInt32;
       First : Index)
    with
-     Pre  => First <= This.Capacity      and then
-             High_Water_Mark (This) >= First + 3,
-     Post => Position (This) = Position (This)'Old                         and then
-             High_Water_Mark (This) = High_Water_Mark (This)'Old           and then
-             Remaining (This) = Remaining (This)'Old                       and then
-             Raw_Bytes (This) = Raw_Bytes (This)'Old;
+     Pre  => First <= This.Capacity - 3 and then
+             First + 3 <= High_Water_Mark (This) - 1,
+     Post => Position (This) = Position (This)'Old               and then
+             High_Water_Mark (This) = High_Water_Mark (This)'Old and then
+             Remaining (This) = Remaining (This)'Old             and then
+             Raw_Bytes (This) = Raw_Bytes (This)'Old             and then
+             Raw_Bytes (This) (First .. First + 3) = As_Four_Bytes (Value);
    --  Gets the four bytes comprising a UInt32 value from This buffer, starting
    --  at absolute index First (rather than from This.Position)
 
@@ -175,7 +177,6 @@ is
        Position (This) <= High_Water_Mark (This) - 2,
        --  The string content is preceded in the buffer by a two-byte length,
        --  even when the string length is zero (ie when the string is empty).
-
      Post =>
        High_Water_Mark (This) = High_Water_Mark (This)'Old and then
        Stored_Length <= Max_String_Length                  and then
@@ -355,8 +356,7 @@ is
    --  already. That also means that there is no two-byte length restriction.
 
    procedure Put_Raw_Bytes (This : in out ByteBuffer'Class; Value : String) with
-     Pre  => Value'Length <= Max_String_Length and then
-             Remaining (This) >= Value'Length  and then
+     Pre  => Remaining (This) >= Value'Length  and then
              High_Water_Mark (This) + Value'Length <= This.Capacity,
      Post => Position (This) = Position (This)'Old + Value'Length               and then
              High_Water_Mark (This) = High_Water_Mark (This)'Old + Value'Length and then
@@ -377,13 +377,13 @@ is
              Prior_Content_Unchanged (This, Old_Value => This'Old);
 
    function Raw_Bytes (This : ByteBuffer'Class) return Byte_Array;
-   --  Returns the internal byte array content, up to High_Water_Mark (This)
+   --  Returns the entire internal byte array content, up to High_Water_Mark (This)
 
-   function Raw_Bytes (This : ByteBuffer'Class) return String with
-     Post => Raw_Bytes'Result'First = 1 and then
-             Raw_Bytes'Result'Length = Index'Min (Max_String_Length, High_Water_Mark (This));
-   --  Returns the internal byte array content, up to High_Water_Mark (This),
-   --  as a String
+   function Raw_Bytes_As_String (This : ByteBuffer'Class) return String with
+     Pre  => High_Water_Mark (This) <= Index (Positive'Last),
+     Post => Raw_Bytes_As_String'Result'First = 1 and then
+             Raw_Bytes_As_String'Result'Length = High_Water_Mark (This);
+   --  Returns the entire internal byte array content, as a String
 
    function Checksum (This : ByteBuffer'Class;  Last : Index) return UInt32 with
      Pre => Last <= This.Capacity;
@@ -430,8 +430,7 @@ is
       Boolean
    with
      Ghost,
-     Pre => Comparand'Length <= Max_String_Length  and then
-            This.Capacity >= Comparand'Length      and then
+     Pre => This.Capacity >= Comparand'Length      and then
             Start <= Index'Last - Comparand'Length and then
             Start <= This.Capacity - Comparand'Length;
    --  Returns whether the slice of This, starting at Start, equals the
@@ -475,9 +474,7 @@ private
    ---------------
 
    function Raw_Bytes (This : ByteBuffer'Class) return Byte_Array is
-     (if This.Highest_Write_Pos > 0
-      then This.Content (0 .. This.Highest_Write_Pos - 1)
-      else This.Content (1 .. 0));
+      (This.Content (0 .. This.Highest_Write_Pos - 1));
 
    ---------------
    -- Remaining --

--- a/src/templates/ada/avtas/lmcp/prove_bytebuffers.adb
+++ b/src/templates/ada/avtas/lmcp/prove_bytebuffers.adb
@@ -1,0 +1,333 @@
+with AVTAS.LMCP.ByteBuffers; use AVTAS.LMCP.ByteBuffers;
+with Ada.Text_IO;            use Ada.Text_IO;
+with Ada.Assertions;         use Ada.Assertions;
+with Ada.Strings.Unbounded;
+with AVTAS.LMCP.Types;       use AVTAS.LMCP.Types;
+with Ada.Unchecked_Deallocation;
+
+procedure Prove_ByteBuffers with
+   SPARK_Mode
+is
+   package ASU renames Ada.Strings.Unbounded;
+begin
+
+   pragma Warnings (Off, "has no effect");
+   pragma Warnings (Off, "not used after the call");
+
+--  get from relative index after rewind -------------------------------------
+
+   declare
+      C : constant := 100; -- arbitrary
+      B : ByteBuffer (Capacity => C);
+      V : UInt16;
+   begin
+      Put_Line ("Get (first) value after rewind");
+      B.Put_Uint16 (42);
+      B.Rewind;
+      B.Get_UInt16 (V);
+      pragma Assert (V = 42);
+   end;
+
+--  get from absolute index --------------------------------------------------
+
+   declare
+      --                                  123456789ABC
+      String_Input  : constant String := "Hello World!";
+      Index_After_String : constant := 2 + String_Input'Length;
+      --  the 2-byte length of the string precedes the actual string content so
+      --  we add 2
+
+      UInt32_Input  : constant UInt32 := 42;
+      Byte_Input    : constant Byte := 42;
+
+      Expected_High_Water_Mark : constant := 2 + String_Input'Length + 4 + 1;
+      --  2-bytes for string length + length of string + 4 bytes for uint32 + 1 byte for boolean
+
+      Buffer : ByteBuffer (Capacity => 100);
+   begin
+      Put_Line ("Get_UInt32 from absolute index > position and <= high water mark");
+      Buffer.Put_String (String_Input);
+      Buffer.Put_UInt32 (UInt32_Input);
+      Buffer.Put_Byte (Byte_Input);
+
+      Buffer.Rewind;
+
+      Assert (Position (Buffer) = 0);
+      Assert (High_Water_Mark (Buffer) = Expected_High_Water_Mark);
+
+      --  now we read back one of the written values at an absolute position
+      --  that is greater than the current position but not greater than the
+      --  high water mark, which should succeed
+      declare
+         Output : UInt32;
+      begin
+         Buffer.Get_UInt32 (Output, First => Index_After_String);
+         pragma Assert (Output = UInt32_Input);
+      end;
+   end;
+
+--  inserting strings --------------------------------------------------------
+
+   declare
+      C : constant := 100; -- arbitrary
+      B : ByteBuffer (Capacity => C);
+      L : constant := C - 2;  -- leave room for length inserted into buffer too
+      S : constant String (1 .. L) := (others => 'x');
+   begin
+      Put_Line ("Inserting string with length < capacity");
+      B.Put_String (S);
+   end;
+
+   declare
+      C : constant := UInt16'Last;
+      B : ByteBuffer (Capacity => C + 2);
+      S : constant String (1 .. Integer (UInt16'Last)) := (others => 'x');
+   begin
+      Put_Line ("Inserting string with length = UInt16'Last, with sufficient capacity");
+      B.Put_String (S);
+   end;
+
+--  getting Strings ----------------------------------------------------------
+
+   declare
+      C : constant := 100; -- arbitrary
+      B : ByteBuffer (Capacity => C);
+      Corrupted_String_Length : constant := C + 1; -- anything > C will do
+      S : String (1 .. Corrupted_String_Length) := (others => ' ');
+      Last : Integer;
+      Unused : UInt32;
+   begin
+      Put_Line ("Getting string with stored length > remaining bytes in message");
+      --  Write a value that Get_String is going to read as the length of the
+      --  string in the message. The value must be > buffer capacity.
+      B.Put_UInt16 (Corrupted_String_Length);
+      --  Prepare to start getting values as if a message is in the buffer,
+      --  starting with a string. The actual characters are immaterial so we
+      --  don't bother to insert them into the buffer.
+      --
+      --  Note that this wouldn't happen without some sort of buffer
+      --  corruption because Put_String would have failed when attempting to
+      --  write that any chars into the buffer (since we know the buffer isn't
+      --  big enough in this test, on purpose).
+
+      B.Rewind;
+      B.Get_String (S, Last, Unused);
+      pragma Assert (B.Position = 2);
+      pragma Assert (Last = -1);
+   end;
+
+   -- the case in which stored length > string arg length AND we just set Last to -1
+   declare
+      C : constant := 10; -- arbitrary
+      B : ByteBuffer (Capacity => C);
+      Written : constant String (1 .. 8) := "helloyou";
+      Read : String (1 .. 5) := (others => ' ');
+      Last : Integer;
+      Stored_Length : UInt32;
+   begin
+      Put_Line ("Getting string with stored length > arg length");
+      B.Put_String (Written);
+      B.Rewind;
+      B.Get_String (Read, Last, Stored_Length);
+
+      pragma Assert (Last = -1);
+      pragma Assert (B.Position = 2);
+   end;
+
+   declare
+      C : constant := 100; -- arbitrary
+      B : ByteBuffer (Capacity => C);
+      Written : constant String (1 .. 5) := "world";
+      Read : String (1 .. 10) := (others => ' ');
+      Last : Integer;
+      Unused : UInt32;
+   begin
+      Put_Line ("Getting string with stored length < arg length");
+      B.Put_String (Written);
+      --  prepare to start getting values as if a message is in the buffer,
+      --  starting with a string
+      B.Rewind;
+      B.Get_String (Read, Last, Unused);
+      pragma Assert (Last = Written'Length);
+      pragma Assert (Read (1 .. Last) = Written);
+   end;
+
+--  writing unbounded strings -------------------------------------------------
+
+   declare
+      C : constant := 100; -- arbitrary
+      L : constant := C - 2;  -- leave room for length inserted into buffer too
+      B : ByteBuffer (Capacity => C);
+      S : constant ASU.Unbounded_String := ASU.To_Unbounded_String (Source => String'(1 .. L => 'x'));
+   begin
+      Put_Line ("Inserting unbounded string with length < capacity");
+      B.Put_Unbounded_String (S);
+   end;
+
+   declare
+      C : constant := 2;  -- the 2 bytes for the string's bounds
+      B : ByteBuffer (Capacity => C);
+      L : constant := 0;
+      S : constant ASU.Unbounded_String := ASU.To_Unbounded_String (Source => String'(1 .. L => 'x'));
+   begin
+      Put_Line ("Inserting unbounded string with length = 0, with sufficient capacity");
+      B.Put_Unbounded_String (S);
+   end;
+
+   declare
+      C : constant := 100; -- arbitrary
+      L : constant := C - 2;  -- leave room for length inserted into buffer too
+      B : ByteBuffer (Capacity => C);
+      S : constant ASU.Unbounded_String := ASU.To_Unbounded_String (Source => String'(1 .. L => 'x'));
+   begin
+      Put_Line ("Inserting unbounded string with length < capacity");
+      B.Put_Unbounded_String (S);
+   end;
+
+--  reading unbounded strings -------------------------------------------------
+
+   declare
+      C : constant := Max_String_Length;
+      B : ByteBuffer (Capacity => C + 2);
+      L : constant := Integer (C);
+      S : constant ASU.Unbounded_String := ASU.To_Unbounded_String (Source => String'(1 .. L => 'x'));
+      O : ASU.Unbounded_String := ASU.To_Unbounded_String (Length => L);
+      Num_Stored : UInt32;
+      use ASU;
+   begin
+      Put_Line ("Getting unbounded string with length = Max_String_Length, with sufficient capacity");
+      B.Put_Unbounded_String (S);
+      B.Rewind;
+      B.Get_Unbounded_String (O, Num_Stored);
+      pragma Assert (Num_Stored = Max_String_Length);
+      pragma Assert (O = S);
+   end;
+
+--  raw bytes ----------------------------------------------------------------
+
+   declare
+      C : constant := 100; -- arbitrary
+      B : ByteBuffer (Capacity => C);
+      L : constant := C - 2;  -- leave room for length inserted into buffer too
+      S : constant String (1 .. L) := (others => 'x');
+   begin
+      Put_Line ("Inserting raw bytes from String with length < capacity");
+      B.Put_Raw_Bytes (S);
+   end;
+
+   declare
+      C : constant := 100; -- arbitrary
+      B : ByteBuffer (Capacity => C);
+      L : constant := C - 2;  -- leave room for length inserted into buffer too
+      S : constant Byte_Array (1 .. L) := (others => Character'Pos ('x'));
+   begin
+      Put_Line ("Inserting raw bytes with length < capacity");
+      B.Put_Raw_Bytes (S);
+   end;
+
+   declare
+      C : constant := UInt32 (Positive'Last) + 10;
+      type ByteBuffer_Pointer is access ByteBuffer;
+      BBP : ByteBuffer_Pointer := new ByteBuffer (C);
+
+      L : constant := Positive'Last;
+      subtype Constrained_Byte_Array is Byte_Array (1 .. L);
+      type Byte_Array_Pointer is access Constrained_Byte_Array;
+      BAP : Byte_Array_Pointer := new Byte_Array'(1 .. L => Character'Pos ('x'));
+
+      procedure Free is new Ada.Unchecked_Deallocation
+        (Object => ByteBuffer, Name => ByteBuffer_Pointer);
+      procedure Free is new Ada.Unchecked_Deallocation
+        (Object => Constrained_Byte_Array, Name => Byte_Array_Pointer);
+   begin
+      Put_Line ("Inserting raw bytes with length = Positive'Last");
+      BBP.Put_Raw_Bytes (BAP.all);
+      --  and free them to keep SPARK happy
+      Free (BAP);
+      Free (BBP);
+   end;
+
+--  sequence of writes followed by sequence of reads  ------------------------
+
+   declare
+      Byte_Input    : constant Byte := 42;
+      String_Input  : constant String := "Hello World!";
+      UInt32_Input  : constant UInt32 := 42;
+      Real32_Input  : constant Real32 := 42.42;
+      Boolean_Input : constant Boolean := True;
+      UInt64_Input  : constant UInt64 := 84;
+
+      Buffer : ByteBuffer (Capacity => 1024);
+   begin
+      Put_Line ("Multiple writes folowed by reads of those written values");
+
+      --  NB: the order of the following must match the order of the calls to Get_* below
+      Buffer.Put_Byte (Byte_Input);
+      Buffer.Put_String (String_Input);
+      Buffer.Put_UInt32 (UInt32_Input);
+      Buffer.Put_Unbounded_String (ASU.To_Unbounded_String (String_Input));
+      Buffer.Put_Real32 (Real32_Input);
+      Buffer.Put_Boolean (Boolean_Input);
+      Buffer.Put_UInt64 (UInt64_Input);
+
+      --  now we read back what was written
+
+      Buffer.Rewind;
+
+      declare
+         Output : Byte;
+      begin
+         Buffer.Get_Byte (Output);
+         pragma Assert (Output = Byte_Input);
+      end;
+
+      declare
+         Output : String (String_Input'Range) := (others => ' ');
+         Last   : Integer;  -- because result can be -1 to signal a problem
+         Unused : UInt32;
+      begin
+         Buffer.Get_String (Output, Last, Unused);
+         pragma Assert (Last = String_Input'Length);
+         pragma Assert (Output (1 .. Last) = String_Input);
+      end;
+
+      declare
+         Output : UInt32;
+      begin
+         Buffer.Get_UInt32 (Output);
+         pragma Assert (Output = UInt32_Input);
+      end;
+
+      declare
+         Output : ASU.Unbounded_String;
+         Num_Stored : UInt32;
+      begin
+         Buffer.Get_Unbounded_String (Output, Num_Stored);
+         pragma Assert (Num_Stored = String_Input'Length);
+         pragma Assert (ASU.To_String (Output) = String_Input);
+      end;
+
+      declare
+         Output : Real32;
+      begin
+         Buffer.Get_Real32 (Output);
+         pragma Assert (Output = Real32_Input);
+      end;
+
+      declare
+         Output : Boolean;
+      begin
+         Buffer.Get_Boolean (Output);
+         pragma Assert (Output = Boolean_Input);
+      end;
+
+      declare
+         Output : UInt64;
+      begin
+         Buffer.Get_UInt64 (Output);
+         pragma Assert (Output = UInt64_Input);
+      end;
+   end;
+
+   Put_Line ("Done");  -- just in case you actually want to run this
+end Prove_ByteBuffers;

--- a/src/templates/ada/avtas/test_bytebuffers.gpr
+++ b/src/templates/ada/avtas/test_bytebuffers.gpr
@@ -2,7 +2,7 @@ project Test_ByteBuffers is
 
    for Source_Dirs use (".", "lmcp");
 
-   for Main use ("test_bytebuffers.adb");
+   for Main use ("prove_bytebuffers.adb", "test_bytebuffers.adb");
 
    type Modes is ("debug", "release");
    Mode : Modes := external ("Build", "debug");
@@ -15,7 +15,8 @@ project Test_ByteBuffers is
    for Object_Dir use "objs/" & Mode;
 
    Unconditional_Compiler_Switches :=
-     ("-gnatyO"    -- check that overriding subprograms are explicitly marked as such
+     ("-gnatyO"      -- check that overriding subprograms are explicitly marked as such
+      , "-gnat2022"  -- enable Ada 2022
       );
 
    Debug_Switches := ("-g",


### PR DESCRIPTION
overall:
   use safer memcopy (memcpy_s),
   weaken overly strong precondition on Put_Raw_String that checked length against Max_String_Length,
   simplify proof code in copying package body using loops

package spec AVTAS.LMCP.ByteBuffers:
   remove too-strong precondition subexpression on procedure Put_Raw_Bytes,
   same for function New_Content_Equal

package spec AVTAS.LMCP.ByteBuffers.Copying:
   procedure Copy_Buffer_To_Unbounded_String now compares input length arg to String's max index, not Max_String_Length,
   procedure Copy_String_To_Buffer doesn't need to check input length against Max_String_Length

avtas-lmcp-bytebuffers-copying-provable_adb:
   reduce number of loop invariants required for proof in general

avtas-lmcp-bytebuffers-copying-performant_adb:
   use "safe" version of memcpy, ie memcpy_s,
   now requires gnat2022 switch due to revision of another routine

Ada.Strings.Unbounded:
   extend postconditions, especially for Append, for sake of proof in ByteBuffers code

test_bytebuffers.adb:
   make explicit that we are testing against Max_String_Length,
   minor formatting of output for readability

prove_bytebuffers.adb:
   Create an additional client main procedure used for verifying client usage of the ByteBuffers ADT. This main procedure is SPARK compliant, unlike Test_ByteBuffers. Because it is intended to prove only successful client use-cases, it contains a subset of the checks in Test_ByteBufers. Note that not all assertions in this client main procedure will prove successfully in this initial version. The first purpose of this procedure is to verify that calls to the ByteBuffer routines themselves are provable. Later, we intend to be able to prove the assertions about client usage, which is largely a matter of sufficient postconditions for the routines.

test_bytebuffers.gpr:
   Add the new main procedure Prove_ByteBuffers to the project GPR file, as the default main. As the default, the SPARK-compliant Prove_ByteBuffers procedure will be analyzed when we tell gnatprove to prove all the files.
   Add -gnat2022 switch for sake of simpler version of Overlapping using a declare-expression