### PR TITLE
apply relaxed initialization to LMCP ByteBuffers facility

### DIFF
--- a/src/avtas/lmcp/lmcpgen/AdaMethods.java
+++ b/src/avtas/lmcp/lmcpgen/AdaMethods.java
@@ -943,10 +943,10 @@ public class AdaMethods {
             String fieldname = getDeconflictedName(st.fields[i].name);
             switch (getAdaTypeCategory(infos,st.fields[i])) {
                 case SINGLE_PRIMITIVE:
-                        str += ws + "   Buffer.Put_" + getAdaPrimativeType(infos, st.fields[i]) + "(This." + fieldname + ");\n";
+                        str += ws + "   Put_" + getAdaPrimativeType(infos, st.fields[i]) + "(Buffer, This." + fieldname + ");\n";
                     break;
                 case SINGLE_ENUM:
-                    str += ws + "   Buffer.Put_Int32(toInt32(This." + fieldname + "));\n";
+                    str += ws + "   Put_Int32(Buffer, toInt32(This." + fieldname + "));\n";
                     break;
                 case SINGLE_NODE_STRUCT:
                 case SINGLE_LEAF_STRUCT:
@@ -954,33 +954,33 @@ public class AdaMethods {
                     break;
                 case VECTOR_PRIMITIVE:
                     if (st.fields[i].isLargeArray) {
-                        str += ws + "   Buffer.Put_UInt32(UInt32(This." + fieldname + ".Length));\n";
+                        str += ws + "   Put_UInt32(Buffer, UInt32(This." + fieldname + ".Length));\n";
                     }
                     else {
-                        str += ws + "   Buffer.Put_UInt16(UInt16(This." + fieldname + ".Length));\n";
+                        str += ws + "   Put_UInt16(Buffer, UInt16(This." + fieldname + ".Length));\n";
                     }
                     str += ws + "   for i of This." + fieldname + ".all loop\n";
-                    str += ws + "      Buffer.Put_" + getAdaPrimativeType(infos, st.fields[i]) + "(i);\n";
+                    str += ws + "      Put_" + getAdaPrimativeType(infos, st.fields[i]) + "(Buffer, i);\n";
                     str += ws + "   end loop;\n";
                     break;
                 case VECTOR_ENUM:
                     if (st.fields[i].isLargeArray) {
-                        str += ws + "   Buffer.Put_UInt32(UInt32(This." + fieldname + ".Length));\n";
+                        str += ws + "   Put_UInt32(Buffer, UInt32(This." + fieldname + ".Length));\n";
                     }
                     else {
-                        str += ws + "   Buffer.Put_UInt16(UInt16(This." + fieldname + ".Length));\n";
+                        str += ws + "   Put_UInt16(Buffer, UInt16(This." + fieldname + ".Length));\n";
                     }
                     str += ws + "   for i of This." + fieldname + ".all loop\n";
-                    str += ws + "      Buffer.Put_Int32(toInt32(i));\n";
+                    str += ws + "      Put_Int32(Buffer, toInt32(i));\n";
                     str += ws + "   end loop;\n";
                     break;
                 case VECTOR_NODE_STRUCT:
                 case VECTOR_LEAF_STRUCT:
                     if (st.fields[i].isLargeArray) {
-                        str += ws + "   Buffer.Put_UInt32(UInt32(This." + fieldname + ".Length));\n";
+                        str += ws + "   Put_UInt32(Buffer, UInt32(This." + fieldname + ".Length));\n";
                     }
                     else {
-                        str += ws + "   Buffer.Put_UInt16(UInt16(This." + fieldname + ".Length));\n";
+                        str += ws + "   Put_UInt16(Buffer, UInt16(This." + fieldname + ".Length));\n";
                     }
                     str += ws + "   for i of This." + fieldname + ".all loop\n";
                     str += ws + "      AVTAS.LMCP.Factory.putObject(AVTAS.LMCP.Object.Object_Any(i), Buffer);\n";
@@ -989,13 +989,13 @@ public class AdaMethods {
                 case FIXED_ARRAY_PRIMITIVE:
                     //str += ws + "   Put_UInt32(UInt32(This." + fieldname + "'Length), Buffer);\n";
                     str += ws + "   for i of This." + fieldname + ".all loop\n";
-                    str += ws + "      Buffer.Put_" + getAdaPrimativeType(infos, st.fields[i]) + "(i);\n";
+                    str += ws + "      Put_" + getAdaPrimativeType(infos, st.fields[i]) + "(Buffer, i);\n";
                     str += ws + "   end loop;\n";
                     break;
                 case FIXED_ARRAY_ENUM:
                     //str += ws + "   Put_UInt32(UInt32(This." + fieldname + "'Length), Buffer);\n";
                     str += ws + "   for i of This." + fieldname + ".all loop\n";
-                    str += ws + "      Buffer.Put_Int32(toInt32(i));\n";
+                    str += ws + "      Put_Int32(Buffer, toInt32(i));\n";
                     str += ws + "   end loop;\n";
                     break;
                 case FIXED_ARRAY_NODE_STRUCT:
@@ -1029,17 +1029,17 @@ public class AdaMethods {
                         str += ws + "   declare\n";
                         str += ws + "      Unused : UInt32;\n";
                         str += ws + "   begin\n";
-                        str += ws + "      Buffer.Get_Unbounded_String (This." + fieldname + ", Unused);\n";
+                        str += ws + "      Get_Unbounded_String (Buffer, This." + fieldname + ", Unused);\n";
                         str += ws + "   end;\n";
                     } else {
-                        str += ws + "   Buffer.Get_" + getAdaPrimativeType(infos, st.fields[i]) + "(This." + fieldname + ");\n";
+                        str += ws + "   Get_" + getAdaPrimativeType(infos, st.fields[i]) + "(Buffer, This." + fieldname + ");\n";
                     }
                     break;
                 case SINGLE_ENUM:
                     str += ws + "   declare\n";
                     str += ws + "      i32 : Int32;\n";
                     str += ws + "   begin\n";
-                    str += ws + "      Buffer.Get_Int32(i32);\n";
+                    str += ws + "      Get_Int32(Buffer, i32);\n";
                     str += ws + "      This." + fieldname + " := toEnum(i32);\n";
                     str += ws + "   end;\n";
                     break;
@@ -1054,11 +1054,11 @@ public class AdaMethods {
                     str += ws + "      msgType : UInt32;\n";
                     str += ws + "      version : UInt16;\n";
                     str += ws + "   begin\n";
-                    str += ws + "      Buffer.Get_Boolean(fieldExists);\n";
+                    str += ws + "      Get_Boolean(Buffer, fieldExists);\n";
                     str += ws + "      if fieldExists then\n";
-                    str += ws + "         Buffer.Get_Int64(seriesId);\n";
-                    str += ws + "         Buffer.Get_UInt32(msgType);\n";
-                    str += ws + "         Buffer.Get_UInt16(version);\n";
+                    str += ws + "         Get_Int64(Buffer, seriesId);\n";
+                    str += ws + "         Get_UInt32(Buffer, msgType);\n";
+                    str += ws + "         Get_UInt16(Buffer, version);\n";
                     str += ws + "         " + component_name + " := " + fieldtype + "(AVTAS.LMCP.Factory.createObject(seriesId, msgType, version));\n";
                     str += ws + "         " + component_name + ".Unpack (Buffer);\n";
                     str += ws + "      end if;\n";
@@ -1070,16 +1070,16 @@ public class AdaMethods {
                     if (st.fields[i].isLargeArray) {
                         str += ws + "      length : UInt32;\n";
                         str += ws + "   begin\n";
-                        str += ws + "      Buffer.Get_UInt32(length);\n";
+                        str += ws + "      Get_UInt32(Buffer, length);\n";
                     }
                     else {
                         str += ws + "      length : UInt16;\n";
                         str += ws + "   begin\n";
-                        str += ws + "      Buffer.Get_UInt16(length);\n";
+                        str += ws + "      Get_UInt16(Buffer, length);\n";
                     }
                     str += ws + "      This.get" + fieldname + ".Clear;  -- delete old content\n";
                     str += ws + "      for i in 1 .. length loop\n";
-                    str += ws + "         Buffer.Get_" + getAdaPrimativeType(infos, st.fields[i]) + "(item);\n";
+                    str += ws + "         Get_" + getAdaPrimativeType(infos, st.fields[i]) + "(Buffer, item);\n";
                     str += ws + "         This.get" + fieldname + ".Append(item);\n";
                     str += ws + "      end loop;\n";
                     str += ws + "   end;\n";
@@ -1090,16 +1090,16 @@ public class AdaMethods {
                     if (st.fields[i].isLargeArray) {
                         str += ws + "      length : UInt32;\n";
                         str += ws + "   begin\n";
-                        str += ws + "      Buffer.Get_UInt32(length);\n";
+                        str += ws + "      Get_UInt32(Buffer, length);\n";
                     }
                     else {
                         str += ws + "      length : UInt16;\n";
                         str += ws + "   begin\n";
-                        str += ws + "      Buffer.Get_UInt16(length);\n";
+                        str += ws + "      Get_UInt16(Buffer, length);\n";
                     }
                     str += ws + "      This.get" + fieldname + ".Clear;  -- delete old content\n";
                     str += ws + "      for i in 1 .. length loop\n";
-                    str += ws + "         Buffer.Get_Int32(item);\n";
+                    str += ws + "         Get_Int32(Buffer, item);\n";
                     str += ws + "         This.get" + fieldname + ".Append(ToEnum(item));\n";
                     str += ws + "      end loop;\n";
                     str += ws + "   end;\n";
@@ -1117,14 +1117,14 @@ public class AdaMethods {
                     str += ws + "      item : " + fieldType + ";\n";
                     str += ws + "      length : " + lengthType + ";\n";
                     str += ws + "   begin\n";
-                    str += ws + "      Buffer.Get_" + lengthType + "(length);\n";
+                    str += ws + "      Get_" + lengthType + "(Buffer, length);\n";
                     str += ws + "      This.get" + fieldname + ".Clear;  -- delete old content\n";
                     str += ws + "      for i in 1 .. length loop\n";
-                    str += ws + "         Buffer.Get_Boolean(fieldExists);\n";
+                    str += ws + "         Get_Boolean(Buffer, fieldExists);\n";
                     str += ws + "         if fieldExists then\n";
-                    str += ws + "            Buffer.Get_Int64(seriesId);\n";
-                    str += ws + "            Buffer.Get_UInt32(msgType);\n";
-                    str += ws + "            Buffer.Get_UInt16(version);\n";
+                    str += ws + "            Get_Int64(Buffer, seriesId);\n";
+                    str += ws + "            Get_UInt32(Buffer, msgType);\n";
+                    str += ws + "            Get_UInt16(Buffer, version);\n";
                     str += ws + "            item := " + fieldType + "(AVTAS.LMCP.Factory.createObject(seriesId, msgType, version));\n";
                     str += ws + "            item.unpack(Buffer);\n";
                     str += ws + "         end if;\n";
@@ -1137,7 +1137,7 @@ public class AdaMethods {
                     str += ws + "      item : " + getAdaPrimativeType(infos, st.fields[i]) + ";\n";
                     str += ws + "   begin\n";
                     str += ws + "      for i in This.get" + fieldname + "\'Range loop\n";
-                    str += ws + "         Buffer.Get_" + getAdaPrimativeType(infos, st.fields[i]) + "(item);\n";
+                    str += ws + "         Get_" + getAdaPrimativeType(infos, st.fields[i]) + "(Buffer, item);\n";
                     str += ws + "         This.get" + fieldname + "(i) := item;\n";
                     str += ws + "      end loop;\n";
                     str += ws + "   end;\n";
@@ -1147,7 +1147,7 @@ public class AdaMethods {
                     str += ws + "      item : Int32;\n";
                     str += ws + "   begin\n";
                     str += ws + "      for i in This.get" + fieldname + "\'Range loop\n";
-                    str += ws + "         Buffer.Get_Int32(item);\n";
+                    str += ws + "         Get_Int32(Buffer, item);\n";
                     str += ws + "         This.get" + fieldname + "(i) := toEnum(item);\n";
                     str += ws + "      end loop;\n";
                     str += ws + "   end;\n";
@@ -1165,11 +1165,11 @@ public class AdaMethods {
                     str += ws + "      item : " + fieldType + ";\n";
                     str += ws + "   begin\n";
                     str += ws + "      for i in This.get" + fieldname + "\'Range loop\n";
-                    str += ws + "         Buffer.Get_Boolean(fieldExists);\n";
+                    str += ws + "         Get_Boolean(Buffer, fieldExists);\n";
                     str += ws + "         if fieldExists then\n";
-                    str += ws + "            Buffer.Get_Int64(seriesId);\n";
-                    str += ws + "            Buffer.Get_UInt32(msgType);\n";
-                    str += ws + "            Buffer.Get_UInt16(version);\n";
+                    str += ws + "            Get_Int64(Buffer, seriesId);\n";
+                    str += ws + "            Get_UInt32(Buffer, msgType);\n";
+                    str += ws + "            Get_UInt16(Buffer, version);\n";
                     str += ws + "            item := " + fieldType + "(AVTAS.LMCP.Factory.createObject(seriesId, msgType, version));\n";
                     str += ws + "            item.unpack(Buffer);\n";
                     str += ws + "         else\n";

--- a/src/templates/ada/avtas/lmcp/a-strunb.adb
+++ b/src/templates/ada/avtas/lmcp/a-strunb.adb
@@ -6,7 +6,7 @@
 --                                                                          --
 --                                 B o d y                                  --
 --                                                                          --
---          Copyright (C) 1992-2021, Free Software Foundation, Inc.         --
+--          Copyright (C) 1992-2022, Free Software Foundation, Inc.         --
 --                                                                          --
 -- GNAT is free software;  you can  redistribute it  and/or modify it under --
 -- terms of the  GNU General Public License as published  by the Free Soft- --

--- a/src/templates/ada/avtas/lmcp/a-strunb.ads
+++ b/src/templates/ada/avtas/lmcp/a-strunb.ads
@@ -83,10 +83,10 @@ private with System.Atomic_Counters;
 private with Ada.Strings.Text_Buffers;
 
 package Ada.Strings.Unbounded with
-  Initial_Condition => Length (Null_Unbounded_String) = 0
+  Initial_Condition => Length (Null_Unbounded_String) = 0,
+  Always_Terminates
 is
    pragma Preelaborate;
-   pragma Annotate (GNATprove, Always_Return, Unbounded);
    pragma Unevaluated_Use_Of_Old (Allow);
 
    type Unbounded_String is private with

--- a/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers-copying-performant_adb
+++ b/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers-copying-performant_adb
@@ -1,55 +1,75 @@
 with System.Storage_Elements;  use System.Storage_Elements;
 
 package body AVTAS.LMCP.ByteBuffers.Copying with
-   SPARK_Mode => Off
+   SPARK_Mode
 is
 
    -----------------
    -- Overlapping --
    -----------------
 
-   function Overlapping (Destination, Source : Address; Count : Storage_Count) return Boolean is
-     (for some Location in To_Integer (Destination) .. To_Integer (Destination + Count - 1) =>
-        Location in To_Integer (Source) .. To_Integer (Source + Count - 1))
-   with Pre => Source /= Null_Address and
-               Destination /= Null_Address;
+   function Overlapping (Block_1, Block_2 : Address; Count : Storage_Count) return Boolean is
+     (declare
+        Block_1_First : constant Integer_Address := To_Integer (Block_1);
+        Block_2_First : constant Integer_Address := To_Integer (Block_2);
+        Block_1_Last  : constant Integer_Address := To_Integer (Block_1 + Count - 1);
+        Block_2_Last  : constant Integer_Address := To_Integer (Block_2 + Count - 1);
+      begin
+        (for some Location in Block_1_First .. Block_1_Last =>
+           Location in Block_2_First .. Block_2_Last))
+   with
+      Pre => Block_2 /= Null_Address and
+             Block_1 /= Null_Address;
 
    -------------
    -- MemCopy --
    -------------
 
-   function MemCopy (Destination, Source : Address; Length : Storage_Count) return Address with
+   function MemCopy
+     (Destination      : Address;
+      Destination_Size : Storage_Count;
+      Source           : Address;
+      Count            : Storage_Count)
+   return Integer
+   with
      Inline,
      Import,
      Convention => C,
-     Link_Name => "memcpy",
-     Pre => Source /= Null_Address and then
-            Destination /= Null_Address and then
-            Source /= Destination and then  --- covered by Overlapping but aids comprehension
-            not Overlapping (Destination, Source, Length),
-     Post => MemCopy'Result = Destination;
+     Link_Name => "memcpy_s",
+     Pre  => Source /= Null_Address and then
+             Destination /= Null_Address and then
+             Destination_Size >= Count and then
+             not Overlapping (Destination, Source, Count),
+     Post => MemCopy'Result = 0;
    --  Copies Length bytes from the object designated by Source to the object
-   --  designated by Destination. Note the order of the address parameters is
-   --  critical so use the named association format for specifying actuals in
-   --  calls.
+   --  designated by Destination. Note the order of the address parameters
+   --  is critical so callers should use the named association format for
+   --  specifying actuals in calls.
+   --
+   --  If the result is non-zero but Destination and Destination_Size are
+   --  valid, the region starting at Destination, of Destination_Size bytes,
+   --  will be zeroed. However, the necessary causes of that failure are
+   --  precluded via the preconditions, so we don't check that in the
+   --  postcondition.
 
    ---------------------------
    -- Copy_Buffer_To_String --
    ---------------------------
-   
+
    procedure Copy_Buffer_To_String
      (This        : in out ByteBuffer'Class;
       Length      : Index;
       Destination : in out String)
    is
-      Result : System.Address with Unreferenced;
+      Result : Integer with Unreferenced;  -- checked by postcondition
    begin
-      Result := MemCopy (Source      => This.Content (This.Position)'Address,
-                         Destination => Destination'Address,
-                         Length      => Storage_Count (Length));
+      Result := MemCopy (Source           => This.Content (This.Position)'Address,
+                         Destination      => Destination'Address,
+                         Destination_Size => Destination'Length,
+                         Count            => Storage_Count (Length));
       This.Position := This.Position + Length;
-   end Copy_Buffer_To_String;   
-   
+   end Copy_Buffer_To_String;
+
    -------------------------------------
    -- Copy_Buffer_To_Unbounded_String --
    -------------------------------------
@@ -59,50 +79,52 @@ is
       Length      : Index;
       Destination : out Unbounded_String)
    is
-      Temp    : String (1 .. Integer (Length));
-      Old_Pos : constant Index := This.Position with Ghost;
-      Result  : System.Address with Unreferenced;
+      Buffer_As_String : String (1 .. Integer (Length));
+      Result           : Integer with Unreferenced;  -- checked by postcondition
    begin
-      Result := MemCopy (Source      => This.Content (This.Position)'Address,
-                         Destination => Temp'Address,
-                         Length      => Storage_Count (Length));
+      Result := MemCopy (Source           => This.Content (This.Position)'Address,
+                         Destination      => Buffer_As_String'Address,
+                         Destination_Size => Buffer_As_String'Length,
+                         Count            => Storage_Count (Length));
+      pragma Assert (Equal (Raw_Bytes (This) (This.Position .. This.Position + Length - 1), Buffer_As_String));
       This.Position := This.Position + Length;
-      pragma Assert (Equal (Raw_Bytes (This) (Old_Pos .. Position (This) - 1), Temp));
-      Destination := To_Unbounded_String (Temp);
-   end Copy_Buffer_To_Unbounded_String;   
-     
+      Destination := To_Unbounded_String (Buffer_As_String);
+   end Copy_Buffer_To_Unbounded_String;
+
    ---------------------------
    -- Copy_String_To_Buffer --
    ---------------------------
-   
+
    procedure Copy_String_To_Buffer
      (This : in out ByteBuffer'Class;
       From : String)
    is
-      Result : System.Address with Unreferenced;
+      Result : Integer with Unreferenced;  -- checked by postcondition
    begin
-      Result := MemCopy (Source      => From'Address,
-                         Destination => This.Content (This.Position)'Address,
-                         Length      => Storage_Count (From'Length));
+      Result := MemCopy (Source           => From'Address,
+                         Destination      => This.Content (This.Position)'Address,
+                         Destination_Size => Storage_Count (This.Capacity - This.Position + 1),
+                         Count            => Storage_Count (From'Length));
       This.Highest_Write_Pos := This.Highest_Write_Pos + From'Length;
       This.Position := This.Position + From'Length;
    end Copy_String_To_Buffer;
-   
+
    --------------------------
    -- Copy_Bytes_To_Buffer --
    --------------------------
-   
+
    procedure Copy_Bytes_To_Buffer
      (This : in out ByteBuffer'Class;
       From : Byte_Array)
    is
-      Result : System.Address with Unreferenced;
+      Result : Integer with Unreferenced;  -- checked by postcondition
    begin
-      Result := MemCopy (Source      => From'Address,
-                         Destination => This.Content (This.Position)'Address,
-                         Length      => Storage_Count (From'Length));
+      Result := MemCopy (Source           => From'Address,
+                         Destination      => This.Content (This.Position)'Address,
+                         Destination_Size => Storage_Count (This.Capacity - This.Position + 1),
+                         Count            => Storage_Count (From'Length));
       This.Highest_Write_Pos := This.Highest_Write_Pos + From'Length;
       This.Position := This.Position + From'Length;
    end Copy_Bytes_To_Buffer;
-   
+
 end AVTAS.LMCP.ByteBuffers.Copying;

--- a/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers-copying-performant_adb
+++ b/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers-copying-performant_adb
@@ -1,56 +1,47 @@
 with System.Storage_Elements;  use System.Storage_Elements;
 
-package body AVTAS.LMCP.ByteBuffers.Copying with
-   SPARK_Mode
-is
+package body AVTAS.LMCP.ByteBuffers.Copying is
+
+   function Overlapping (Block_1, Block_2 : Address; Count : Storage_Count) return Boolean with
+      Pre => Block_2 /= Null_Address and
+             Block_1 /= Null_Address;
 
    -----------------
    -- Overlapping --
    -----------------
 
    function Overlapping (Block_1, Block_2 : Address; Count : Storage_Count) return Boolean is
-     (declare
-        Block_1_First : constant Integer_Address := To_Integer (Block_1);
-        Block_2_First : constant Integer_Address := To_Integer (Block_2);
-        Block_1_Last  : constant Integer_Address := To_Integer (Block_1 + Count - 1);
-        Block_2_Last  : constant Integer_Address := To_Integer (Block_2 + Count - 1);
-      begin
-        (for some Location in Block_1_First .. Block_1_Last =>
-           Location in Block_2_First .. Block_2_Last))
-   with
-      Pre => Block_2 /= Null_Address and
-             Block_1 /= Null_Address;
+      Block_1_First : constant Integer_Address := To_Integer (Block_1);
+      Block_2_First : constant Integer_Address := To_Integer (Block_2);
+      Block_1_Last  : constant Integer_Address := To_Integer (Block_1 + Count - 1);
+      Block_2_Last  : constant Integer_Address := To_Integer (Block_2 + Count - 1);
+   begin
+      return (for some Location in Block_1_First .. Block_1_Last =>
+                Location in Block_2_First .. Block_2_Last);
+   end Overlapping;
 
    -------------
    -- MemCopy --
    -------------
 
    function MemCopy
-     (Destination      : Address;
-      Destination_Size : Storage_Count;
-      Source           : Address;
-      Count            : Storage_Count)
+     (Destination : Address;
+      Source      : Address;
+      Count       : Storage_Count)
    return Integer
    with
      Inline,
      Import,
      Convention => C,
-     Link_Name => "memcpy_s",
-     Pre  => Source /= Null_Address and then
+     Link_Name => "memcpy",
+     Pre  => Source /= Null_Address      and then
              Destination /= Null_Address and then
-             Destination_Size >= Count and then
              not Overlapping (Destination, Source, Count),
      Post => MemCopy'Result = 0;
    --  Copies Length bytes from the object designated by Source to the object
    --  designated by Destination. Note the order of the address parameters
    --  is critical so callers should use the named association format for
    --  specifying actuals in calls.
-   --
-   --  If the result is non-zero but Destination and Destination_Size are
-   --  valid, the region starting at Destination, of Destination_Size bytes,
-   --  will be zeroed. However, the necessary causes of that failure are
-   --  precluded via the preconditions, so we don't check that in the
-   --  postcondition.
 
    ---------------------------
    -- Copy_Buffer_To_String --
@@ -63,10 +54,9 @@ is
    is
       Result : Integer with Unreferenced;  -- checked by postcondition
    begin
-      Result := MemCopy (Source           => This.Content (This.Position)'Address,
-                         Destination      => Destination'Address,
-                         Destination_Size => Destination'Length,
-                         Count            => Storage_Count (Length));
+      Result := MemCopy (Source      => This.Content (This.Position)'Address,
+                         Destination => Destination'Address,
+                         Count       => Storage_Count (Length));
       This.Position := This.Position + Length;
    end Copy_Buffer_To_String;
 
@@ -82,10 +72,9 @@ is
       Buffer_As_String : String (1 .. Integer (Length));
       Result           : Integer with Unreferenced;  -- checked by postcondition
    begin
-      Result := MemCopy (Source           => This.Content (This.Position)'Address,
-                         Destination      => Buffer_As_String'Address,
-                         Destination_Size => Buffer_As_String'Length,
-                         Count            => Storage_Count (Length));
+      Result := MemCopy (Source      => This.Content (This.Position)'Address,
+                         Destination => Buffer_As_String'Address,
+                         Count       => Storage_Count (Length));
       pragma Assert (Equal (Raw_Bytes (This) (This.Position .. This.Position + Length - 1), Buffer_As_String));
       This.Position := This.Position + Length;
       Destination := To_Unbounded_String (Buffer_As_String);
@@ -101,12 +90,13 @@ is
    is
       Result : Integer with Unreferenced;  -- checked by postcondition
    begin
-      Result := MemCopy (Source           => From'Address,
-                         Destination      => This.Content (This.Position)'Address,
-                         Destination_Size => Storage_Count (This.Capacity - This.Position + 1),
-                         Count            => Storage_Count (From'Length));
-      This.Highest_Write_Pos := This.Highest_Write_Pos + From'Length;
+      Result := MemCopy (Source      => From'Address,
+                         Destination => This.Content (This.Position)'Address,
+                         Count       => Storage_Count (From'Length));
       This.Position := This.Position + From'Length;
+      if This.Position > This.Highest_Write_Pos then
+         This.Highest_Write_Pos := This.Position;
+      end if;
    end Copy_String_To_Buffer;
 
    --------------------------
@@ -119,12 +109,13 @@ is
    is
       Result : Integer with Unreferenced;  -- checked by postcondition
    begin
-      Result := MemCopy (Source           => From'Address,
-                         Destination      => This.Content (This.Position)'Address,
-                         Destination_Size => Storage_Count (This.Capacity - This.Position + 1),
-                         Count            => Storage_Count (From'Length));
-      This.Highest_Write_Pos := This.Highest_Write_Pos + From'Length;
+      Result := MemCopy (Source      => From'Address,
+                         Destination => This.Content (This.Position)'Address,
+                         Count       => Storage_Count (From'Length));
       This.Position := This.Position + From'Length;
+      if This.Position > This.Highest_Write_Pos then
+         This.Highest_Write_Pos := This.Position;
+      end if;
    end Copy_Bytes_To_Buffer;
 
 end AVTAS.LMCP.ByteBuffers.Copying;

--- a/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers-copying-performant_adb
+++ b/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers-copying-performant_adb
@@ -57,7 +57,7 @@ is
    ---------------------------
 
    procedure Copy_Buffer_To_String
-     (This        : in out ByteBuffer'Class;
+     (This        : in out ByteBuffer;
       Length      : Index;
       Destination : in out String)
    is
@@ -75,7 +75,7 @@ is
    -------------------------------------
 
    procedure Copy_Buffer_To_Unbounded_String
-     (This        : in out ByteBuffer'Class;
+     (This        : in out ByteBuffer;
       Length      : Index;
       Destination : out Unbounded_String)
    is
@@ -96,7 +96,7 @@ is
    ---------------------------
 
    procedure Copy_String_To_Buffer
-     (This : in out ByteBuffer'Class;
+     (This : in out ByteBuffer;
       From : String)
    is
       Result : Integer with Unreferenced;  -- checked by postcondition
@@ -114,7 +114,7 @@ is
    --------------------------
 
    procedure Copy_Bytes_To_Buffer
-     (This : in out ByteBuffer'Class;
+     (This : in out ByteBuffer;
       From : Byte_Array)
    is
       Result : Integer with Unreferenced;  -- checked by postcondition

--- a/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers-copying-provable_adb
+++ b/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers-copying-provable_adb
@@ -62,25 +62,35 @@ is
       From : String)
    is
    begin
-      This.Highest_Write_Pos := This.Highest_Write_Pos + From'Length;
-      for J in Integer range 1 .. From'Length loop
-         This.Content (This.Position) := Character'Pos (From (From'First + (J - 1)));
+      for J in 0 .. From'Length - 1 loop
+         This.Content (This.Position) := Character'Pos (From (From'First + J));
          This.Position := This.Position + 1;
+         if This.Position > This.Highest_Write_Pos then
+            This.Highest_Write_Pos := This.Position;
+         end if;
 
-         pragma Loop_Invariant (This.Position = This.Position'Loop_Entry + Index (J));
-         pragma Loop_Invariant (This.Position <= This.Capacity - From'Length + Index (J));
+         pragma Loop_Invariant (This.Position = This.Position'Loop_Entry + Index (J) + 1);
+         pragma Loop_Invariant (This.Highest_Write_Pos = Index'Max (This.Highest_Write_Pos'Loop_Entry, This.Position));
 
-         --  all the new content assigned so far matches that slice of Value
+         --  no Content before the newly updated part has been changed
          pragma Loop_Invariant
-           (for all K in 1 .. J =>
-              This.Content (This.Position'Loop_Entry + Index (K) - 1) = Character'Pos (From (From'First + (K - 1))));
+           (for all K in 0 .. This.Position'Loop_Entry - 1 =>
+              This.Content (K) = This.Content'Loop_Entry (K));
 
-         --  no content before the newly inserted content has been changed
+         --  all Content updated so far matches component values in From
          pragma Loop_Invariant
-           (if This.Position'Loop_Entry > 0 then -- not empty prior to call
-              (for all K in 0 .. This.Position'Loop_Entry - 1 =>
-                 This.Content (K) = This.Content'Loop_Entry (K)));
+           (for all K in This.Position'Loop_Entry .. This.Position'Loop_Entry + Index (J) =>
+              This.Content (K) = Character'Pos (From (From'First + Natural (K - This.Position'Loop_Entry))));
 
+         --  no Content after the currently updated part, if any exists, is changed
+         pragma Loop_Invariant
+           (for all K in This.Position .. This.Highest_Write_Pos - 1 =>
+              This.Content (K) = This.Content'Loop_Entry (K));
+
+         --  all written Content is initialized
+         pragma Loop_Invariant
+           (for all K in 0 .. This.Highest_Write_Pos - 1 =>
+              This.Content (K)'Initialized);
       end loop;
    end Copy_String_To_Buffer;
 
@@ -93,9 +103,11 @@ is
       From : Byte_Array)
    is
    begin
-      This.Content (This.Position .. This.Position + From'Length - 1) := From;
-      This.Highest_Write_Pos := This.Highest_Write_Pos + From'Length;
+      This.Content (This.Position .. This.Position + From'Length - 1) := Byte_Data (From);
       This.Position := This.Position + From'Length;
+      if This.Position > This.Highest_Write_Pos then
+         This.Highest_Write_Pos := This.Position;
+      end if;
    end Copy_Bytes_To_Buffer;
 
 end AVTAS.LMCP.ByteBuffers.Copying;

--- a/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers-copying-provable_adb
+++ b/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers-copying-provable_adb
@@ -2,6 +2,8 @@ package body AVTAS.LMCP.ByteBuffers.Copying with
    SPARK_Mode
 is
 
+   package ASU renames Ada.Strings.Unbounded;
+
    ---------------------------
    -- Copy_Buffer_To_String --
    ---------------------------
@@ -17,8 +19,6 @@ is
          Destination (Destination'First + Integer (K)) := Character'Val (This.Content (This.Position));
 
          pragma Loop_Invariant (This.Position = This.Position'Loop_Entry + K);
-         pragma Loop_Invariant (This.Position <= This.Capacity - Length + K);
-         pragma Loop_Invariant (This.Position < This.Highest_Write_Pos);
          pragma Loop_Invariant
            (for all J in 0 .. K =>
               Destination (Destination'First + Integer (J)) = Character'Val (This.Content (Old_Pos + J)));
@@ -39,19 +39,15 @@ is
       Old_Pos : constant Index := Position (This) with Ghost;
    begin
       Destination := Null_Unbounded_String;
-      pragma Assume (Ada.Strings.Unbounded.Length (Destination) = 0);
+      pragma Assume (ASU.Length (Destination) = 0);
       for K in 0 .. Length - 1 loop
          Append (Destination, Character'Val (This.Content (This.Position)));
 
-         pragma Loop_Invariant (This.Position = Old_Pos + K);
-         pragma Loop_Invariant (This.Position <= This.Capacity - Length + K);
-         pragma Loop_Invariant (This.Position < This.Highest_Write_Pos);
-         pragma Loop_Invariant (Ada.Strings.Unbounded.Length (Destination) = Integer (K) + 1);
-         pragma Loop_Invariant (Ada.Strings.Unbounded.Length (Destination) < Natural'Last);
-         pragma Loop_Invariant (Ada.Strings.Unbounded.Length (Destination) <= Max_String_Length);
+         pragma Loop_Invariant (ASU.Length (Destination) = 1 + Integer (K));
          pragma Loop_Invariant
            (for all J in 0 .. K =>
               Element (Destination, 1 + Integer (J)) = Character'Val (This.Content (Old_Pos + J)));
+         pragma Loop_Invariant (This.Position = Old_Pos + K);
 
          This.Position := This.Position + 1;
       end loop;

--- a/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers-copying-provable_adb
+++ b/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers-copying-provable_adb
@@ -9,7 +9,7 @@ is
    ---------------------------
 
    procedure Copy_Buffer_To_String
-     (This        : in out ByteBuffer'Class;
+     (This        : in out ByteBuffer;
       Length      : Index;
       Destination : in out String)
    is
@@ -32,7 +32,7 @@ is
    -------------------------------------
 
    procedure Copy_Buffer_To_Unbounded_String
-     (This        : in out ByteBuffer'Class;
+     (This        : in out ByteBuffer;
       Length      : Index;
       Destination : out Unbounded_String)
    is
@@ -58,7 +58,7 @@ is
    ---------------------------
 
    procedure Copy_String_To_Buffer
-     (This : in out ByteBuffer'Class;
+     (This : in out ByteBuffer;
       From : String)
    is
    begin
@@ -89,7 +89,7 @@ is
    --------------------------
 
    procedure Copy_Bytes_To_Buffer
-     (This : in out ByteBuffer'Class;
+     (This : in out ByteBuffer;
       From : Byte_Array)
    is
    begin

--- a/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers-copying.ads
+++ b/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers-copying.ads
@@ -4,7 +4,7 @@ is
    pragma Unevaluated_Use_Of_Old (Allow);
 
    procedure Copy_Buffer_To_String
-     (This        : in out ByteBuffer'Class;
+     (This        : in out ByteBuffer;
       Length      : Index;
       Destination : in out String)
    with
@@ -22,7 +22,7 @@ is
 
 
    procedure Copy_Buffer_To_Unbounded_String
-     (This        : in out ByteBuffer'Class;
+     (This        : in out ByteBuffer;
       Length      : Index;
       Destination : out Unbounded_String)
    with
@@ -39,7 +39,7 @@ is
 
 
    procedure Copy_String_To_Buffer
-     (This : in out ByteBuffer'Class;
+     (This : in out ByteBuffer;
       From : String)
    with
      Pre  => Remaining (This) >= From'Length  and then
@@ -47,12 +47,12 @@ is
      Post => Position (This) = Position (This)'Old + From'Length               and then
              High_Water_Mark (This) = High_Water_Mark (This)'Old + From'Length and then
              Remaining (This) = Remaining (This)'Old - From'Length             and then
-             New_Content_Equal (This, This.Position'Old, From)                 and then
+             New_Content_Equal (This, Position (This)'Old, From)                 and then
              Prior_Content_Unchanged (This, Old_Value => This'Old),
      Inline;
 
    procedure Copy_Bytes_To_Buffer
-     (This : in out ByteBuffer'Class;
+     (This : in out ByteBuffer;
       From : Byte_Array)
    with
      Pre  => Remaining (This) >= From'Length and then

--- a/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers-copying.ads
+++ b/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers-copying.ads
@@ -44,9 +44,11 @@ is
    with
      Pre  => Remaining (This) >= From'Length  and then
              High_Water_Mark (This) + From'Length <= This.Capacity,
-     Post => Position (This) = Position (This)'Old + From'Length               and then
-             High_Water_Mark (This) = High_Water_Mark (This)'Old + From'Length and then
-             Remaining (This) = Remaining (This)'Old - From'Length             and then
+     Post => Position (This) = Position (This)'Old + From'Length                 and then
+             --  High_Water_Mark is incremented iff new Position would exceed it
+             High_Water_Mark (This) >= High_Water_Mark (This)'Old                and then
+             High_Water_Mark (This) <= High_Water_Mark (This)'Old + From'Length  and then
+             Remaining (This) = Remaining (This)'Old - From'Length               and then
              New_Content_Equal (This, Position (This)'Old, From)                 and then
              Prior_Content_Unchanged (This, Old_Value => This'Old),
      Inline;
@@ -58,7 +60,9 @@ is
      Pre  => Remaining (This) >= From'Length and then
              High_Water_Mark (This) + From'Length <= This.Capacity,
      Post => Position (This) = Position (This)'Old + From'Length                   and then
-             High_Water_Mark (This) = High_Water_Mark (This)'Old + From'Length     and then
+             --  High_Water_Mark is incremented iff new Position would exceed it
+             High_Water_Mark (This) >= High_Water_Mark (This)'Old                  and then
+             High_Water_Mark (This) <= High_Water_Mark (This)'Old + From'Length    and then
              Raw_Bytes (This) (Position (This)'Old .. Position (This) - 1) = From  and then
              Prior_Content_Unchanged (This, Old_Value => This'Old),
      Inline;

--- a/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers-copying.ads
+++ b/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers-copying.ads
@@ -27,23 +27,22 @@ is
       Destination : out Unbounded_String)
    with
      Pre  => Remaining (This) >= Length  and then
-             Length <= Max_String_length and then
+             Length <= Index (Positive'Last) and then
              Position (This) + Length <= High_Water_Mark (This),
      Post => Position (This) = Position (This)'Old + Length      and then
              High_Water_Mark (This) = High_Water_Mark (This)'Old and then
              Remaining (This) = Remaining (This)'Old - Length    and then
              Equal (Raw_Bytes (This) (Position (This)'Old .. Position (This) - 1),
-                    To_String (Destination))                  and then
+                    To_String (Destination))                     and then
              Prior_Content_Unchanged (This, Old_Value => This'Old),
      Inline;
- 
- 
+
+
    procedure Copy_String_To_Buffer
      (This : in out ByteBuffer'Class;
       From : String)
    with
      Pre  => Remaining (This) >= From'Length  and then
-             From'Length <= Max_String_Length and then
              High_Water_Mark (This) + From'Length <= This.Capacity,
      Post => Position (This) = Position (This)'Old + From'Length               and then
              High_Water_Mark (This) = High_Water_Mark (This)'Old + From'Length and then

--- a/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers.adb
+++ b/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers.adb
@@ -7,19 +7,19 @@ is
 
    pragma Unevaluated_Use_Of_Old (Allow);
 
-   ---------------
-   -- Raw_Bytes --
-   ---------------
+   -------------------------
+   -- Raw_Bytes_As_String --
+   -------------------------
 
-   function Raw_Bytes (This : ByteBuffer'Class) return String is
-      Length : constant Natural := Natural (Index'Min (Max_String_Length, This.Highest_Write_Pos));
+   function Raw_Bytes_As_String (This : ByteBuffer'Class) return String is
+      Length : constant Natural := Natural (This.Highest_Write_Pos);  -- safe due to precondition
       Result : String (1 .. Length);
    begin
       for K in Result'Range loop
          Result (K) := Character'Val (This.Content (Index (K - 1)));
       end loop;
       return Result;
-   end Raw_Bytes;
+   end Raw_Bytes_As_String;
 
    ------------
    -- Rewind --

--- a/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers.adb
+++ b/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers.adb
@@ -12,7 +12,7 @@ is
    -------------------------
 
    function Raw_Bytes_As_String (This : ByteBuffer) return String is
-      Length : constant Natural := Natural (This.Highest_Write_Pos);  -- safe due to precondition
+      Length : constant Natural := Natural (This.Highest_Write_Pos);
       Result : String (1 .. Length);
    begin
       for K in Result'Range loop
@@ -92,10 +92,10 @@ is
          To_Bytes   => As_Two_Bytes);
 
    begin
-      Value := As_Int16 (This.Content (This.Position .. This.Position + Int16_Size - 1));
+      Value := As_Int16 (Byte_Array (This.Content (This.Position .. This.Position + Int16_Size - 1)));
       Lemma_Two_Bytes_Equal_Int16
         (This_Numeric => Value,
-         These_Bytes  => This.Content (This.Position .. This.Position + Int16_Size - 1));
+         These_Bytes  => Byte_Array (This.Content (This.Position .. This.Position + Int16_Size - 1)));
       This.Position := This.Position + Int16_Size;
    end Get_Int16;
 
@@ -114,10 +114,10 @@ is
          To_Bytes   => As_Two_Bytes);
 
    begin
-      Value := As_UInt16 (This.Content (This.Position .. This.Position + UInt16_Size - 1));
+      Value := As_UInt16 (Byte_Array (This.Content (This.Position .. This.Position + UInt16_Size - 1)));
       Lemma_Two_Bytes_Equal_UInt16
         (This_Numeric => Value,
-         These_Bytes  => This.Content (This.Position .. This.Position + UInt16_Size - 1));
+         These_Bytes  => Byte_Array (This.Content (This.Position .. This.Position + UInt16_Size - 1)));
       This.Position := This.Position + UInt16_Size;
    end Get_UInt16;
 
@@ -136,10 +136,10 @@ is
          To_Bytes   => As_Four_Bytes);
 
    begin
-      Value := As_Int32 (This.Content (This.Position .. This.Position + Int32_Size - 1));
+      Value := As_Int32 (Byte_Array (This.Content (This.Position .. This.Position + Int32_Size - 1)));
       Lemma_Four_Bytes_Equal_Int32
         (This_Numeric => Value,
-         These_Bytes  => This.Content (This.Position .. This.Position + Int32_Size - 1));
+         These_Bytes  => Byte_Array (This.Content (This.Position .. This.Position + Int32_Size - 1)));
       This.Position := This.Position + Int32_Size;
    end Get_Int32;
 
@@ -158,10 +158,10 @@ is
          To_Bytes   => As_Four_Bytes);
 
    begin
-      Value := As_UInt32 (This.Content (This.Position .. This.Position + UInt32_Size - 1));
+      Value := As_UInt32 (Byte_Array (This.Content (This.Position .. This.Position + UInt32_Size - 1)));
       Lemma_Four_Bytes_Equal_UInt32
         (This_Numeric => Value,
-         These_Bytes  => This.Content (This.Position .. This.Position + UInt32_Size - 1));
+         These_Bytes  => Byte_Array (This.Content (This.Position .. This.Position + UInt32_Size - 1)));
       This.Position := This.Position + UInt32_Size;
    end Get_UInt32;
 
@@ -184,10 +184,10 @@ is
          To_Bytes   => As_Four_Bytes);
 
    begin
-      Value := As_UInt32 (This.Content (First .. First + UInt32_Size - 1));
+      Value := As_UInt32 (Byte_Array (This.Content (First .. First + UInt32_Size - 1)));
       Lemma_Four_Bytes_Equal_UInt32
         (This_Numeric => Value,
-         These_Bytes  => This.Content (First .. First + UInt32_Size - 1));
+         These_Bytes  => Byte_Array (This.Content (First .. First + UInt32_Size - 1)));
    end Get_UInt32;
 
    ---------------
@@ -205,10 +205,10 @@ is
          To_Bytes   => As_Eight_Bytes);
 
    begin
-      Value := As_Int64 (This.Content (This.Position .. This.Position + Int64_Size - 1));
+      Value := As_Int64 (Byte_Array (This.Content (This.Position .. This.Position + Int64_Size - 1)));
       Lemma_Eight_Bytes_Equal_Int64
         (This_Numeric => Value,
-         These_Bytes  => This.Content (This.Position .. This.Position + Int64_Size - 1));
+         These_Bytes  => Byte_Array (This.Content (This.Position .. This.Position + Int64_Size - 1)));
       This.Position := This.Position + Int64_Size;
    end Get_Int64;
 
@@ -227,10 +227,10 @@ is
          To_Bytes   => As_Eight_Bytes);
 
    begin
-      Value := As_UInt64 (This.Content (This.Position .. This.Position + UInt64_Size - 1));
+      Value := As_UInt64 (Byte_Array (This.Content (This.Position .. This.Position + UInt64_Size - 1)));
       Lemma_Eight_Bytes_Equal_UInt64
         (This_Numeric => Value,
-         These_Bytes  => This.Content (This.Position .. This.Position + UInt64_Size - 1));
+         These_Bytes  => Byte_Array (This.Content (This.Position .. This.Position + UInt64_Size - 1)));
       This.Position := This.Position + UInt64_Size;
    end Get_UInt64;
 
@@ -266,11 +266,11 @@ is
       --  floating-point type, to ensure the compiler does not see the byte
       --  swapping (in the As_UInt32 instance) as producing an invalid
       --  floating-point value.
-      Value := As_Real32 (This.Content (This.Position .. This.Position + Real32_Size - 1));
+      Value := As_Real32 (Byte_Array (This.Content (This.Position .. This.Position + Real32_Size - 1)));
 
       Lemma_Four_Bytes_Equal_Real32
         (This_Numeric => Value,
-         These_Bytes  => This.Content (This.Position .. This.Position + Real32_Size - 1));
+         These_Bytes  => Byte_Array (This.Content (This.Position .. This.Position + Real32_Size - 1)));
 
       This.Position := This.Position + Real32_Size;
    end Get_Real32;
@@ -307,11 +307,11 @@ is
       -- floating-point type, to ensure the compiler does not see the byte
       -- swapping (in the As_UInt64 instance) as producing an invalid
       -- floating-point value.
-      Value := As_Real64 (This.Content (This.Position .. This.Position + Real64_Size - 1));
+      Value := As_Real64 (Byte_Array (This.Content (This.Position .. This.Position + Real64_Size - 1)));
 
       Lemma_Eight_Bytes_Equal_Real64
         (This_Numeric => Value,
-         These_Bytes  => This.Content (This.Position .. This.Position + Real64_Size - 1));
+         These_Bytes  => Byte_Array (This.Content (This.Position .. This.Position + Real64_Size - 1)));
 
       This.Position := This.Position + Real64_Size;
    end Get_Real64;
@@ -380,8 +380,10 @@ is
    procedure Put_Byte (This : in out ByteBuffer; Value : Byte) is
    begin
       This.Content (This.Position) := Value;
-      This.Highest_Write_Pos := This.Highest_Write_Pos + Byte_Size;
       This.Position := This.Position + Byte_Size;
+      if This.Highest_Write_Pos < This.Position then
+         This.Highest_Write_Pos := This.Position;
+      end if;
    end Put_Byte;
 
    -----------------
@@ -391,8 +393,10 @@ is
    procedure Put_Boolean (This : in out ByteBuffer; Value : Boolean) is
    begin
       This.Content (This.Position) := Boolean'Pos (Value);
-      This.Highest_Write_Pos := This.Highest_Write_Pos + Boolean_Size;
       This.Position := This.Position + Boolean_Size;
+      if This.Highest_Write_Pos < This.Position then
+         This.Highest_Write_Pos := This.Position;
+      end if;
    end Put_Boolean;
 
    ---------------
@@ -401,9 +405,11 @@ is
 
    procedure Put_Int16 (This : in out ByteBuffer; Value : Int16) is
    begin
-      This.Content (This.Position .. This.Position + Int16_Size - 1) := As_Two_Bytes (Value);
-      This.Highest_Write_Pos := This.Highest_Write_Pos + Int16_Size;
+      This.Content (This.Position .. This.Position + Int16_Size - 1) := Byte_Data (As_Two_Bytes (Value));
       This.Position := This.Position + Int16_Size;
+      if This.Highest_Write_Pos < This.Position then
+         This.Highest_Write_Pos := This.Position;
+      end if;
    end Put_Int16;
 
    ----------------
@@ -412,9 +418,11 @@ is
 
    procedure Put_UInt16 (This : in out ByteBuffer; Value : UInt16) is
    begin
-      This.Content (This.Position .. This.Position + UInt16_Size - 1) := As_Two_Bytes (Value);
-      This.Highest_Write_Pos := This.Highest_Write_Pos + UInt16_Size;
+      This.Content (This.Position .. This.Position + UInt16_Size - 1) := Byte_Data (As_Two_Bytes (Value));
       This.Position := This.Position + UInt16_Size;
+      if This.Highest_Write_Pos < This.Position then
+         This.Highest_Write_Pos := This.Position;
+      end if;
    end Put_UInt16;
 
    ---------------
@@ -423,9 +431,11 @@ is
 
    procedure Put_Int32 (This : in out ByteBuffer; Value : Int32) is
    begin
-      This.Content (This.Position .. This.Position + Int32_Size - 1) := As_Four_Bytes (Value);
-      This.Highest_Write_Pos := This.Highest_Write_Pos + Int32_Size;
+      This.Content (This.Position .. This.Position + Int32_Size - 1) := Byte_Data (As_Four_Bytes (Value));
       This.Position := This.Position + Int32_Size;
+      if This.Highest_Write_Pos < This.Position then
+         This.Highest_Write_Pos := This.Position;
+      end if;
    end Put_Int32;
 
    ----------------
@@ -434,9 +444,11 @@ is
 
    procedure Put_UInt32 (This : in out ByteBuffer; Value : UInt32) is
    begin
-      This.Content (This.Position .. This.Position + UInt32_Size - 1) := As_Four_Bytes (Value);
-      This.Highest_Write_Pos := This.Highest_Write_Pos + UInt32_Size;
+      This.Content (This.Position .. This.Position + UInt32_Size - 1) := Byte_Data (As_Four_Bytes (Value));
       This.Position := This.Position + UInt32_Size;
+      if This.Highest_Write_Pos < This.Position then
+         This.Highest_Write_Pos := This.Position;
+      end if;
    end Put_UInt32;
 
    ---------------
@@ -445,9 +457,11 @@ is
 
    procedure Put_Int64 (This : in out ByteBuffer; Value : Int64) is
    begin
-      This.Content (This.Position .. This.Position + Int64_Size - 1) := As_Eight_Bytes (Value);
-      This.Highest_Write_Pos := This.Highest_Write_Pos + Int64_Size;
+      This.Content (This.Position .. This.Position + Int64_Size - 1) := Byte_Data (As_Eight_Bytes (Value));
       This.Position := This.Position + Int64_Size;
+      if This.Highest_Write_Pos < This.Position then
+         This.Highest_Write_Pos := This.Position;
+      end if;
    end Put_Int64;
 
    ----------------
@@ -456,9 +470,11 @@ is
 
    procedure Put_UInt64 (This : in out ByteBuffer; Value : UInt64) is
    begin
-      This.Content (This.Position .. This.Position + UInt64_Size - 1) := As_Eight_Bytes (Value);
-      This.Highest_Write_Pos := This.Highest_Write_Pos + UInt64_Size;
+      This.Content (This.Position .. This.Position + UInt64_Size - 1) := Byte_Data (As_Eight_Bytes (Value));
       This.Position := This.Position + UInt64_Size;
+      if This.Highest_Write_Pos < This.Position then
+         This.Highest_Write_Pos := This.Position;
+      end if;
    end Put_UInt64;
 
    ----------------
@@ -467,9 +483,11 @@ is
 
    procedure Put_Real32 (This : in out ByteBuffer; Value : Real32) is
    begin
-      This.Content (This.Position .. This.Position + Real32_Size - 1) := As_Four_Bytes (Value);
-      This.Highest_Write_Pos := This.Highest_Write_Pos + Real32_Size;
+      This.Content (This.Position .. This.Position + Real32_Size - 1) := Byte_Data (As_Four_Bytes (Value));
       This.Position := This.Position + Real32_Size;
+      if This.Highest_Write_Pos < This.Position then
+         This.Highest_Write_Pos := This.Position;
+      end if;
   end Put_Real32;
 
    ----------------
@@ -478,9 +496,11 @@ is
 
    procedure Put_Real64 (This : in out ByteBuffer; Value : Real64) is
    begin
-      This.Content (This.Position .. This.Position + Real64_Size - 1) := As_Eight_Bytes (Value);
-      This.Highest_Write_Pos := This.Highest_Write_Pos + Real64_Size;
+      This.Content (This.Position .. This.Position + Real64_Size - 1) := Byte_Data (As_Eight_Bytes (Value));
       This.Position := This.Position + Real64_Size;
+      if This.Highest_Write_Pos < This.Position then
+         This.Highest_Write_Pos := This.Position;
+      end if;
   end Put_Real64;
 
    ----------------

--- a/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers.adb
+++ b/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers.adb
@@ -64,7 +64,7 @@ is
    procedure Get_Byte (This : in out ByteBuffer'Class; Value : out Byte) is
    begin
       Value := This.Content (This.Position);
-      This.Position := This.Position + 1;
+      This.Position := This.Position + Byte_Size;
    end Get_Byte;
 
    -----------------
@@ -74,7 +74,7 @@ is
    procedure Get_Boolean (This : in out ByteBuffer'Class; Value : out Boolean) is
    begin
       Value := This.Content (This.Position) /= 0;
-      This.Position := This.Position + 1;
+      This.Position := This.Position + Boolean_Size;
    end Get_Boolean;
 
    ---------------
@@ -92,11 +92,11 @@ is
          To_Bytes   => As_Two_Bytes);
 
    begin
-      Value := As_Int16 (This.Content (This.Position .. This.Position + 1));
+      Value := As_Int16 (This.Content (This.Position .. This.Position + Int16_Size - 1));
       Lemma_Two_Bytes_Equal_Int16
         (This_Numeric => Value,
-         These_Bytes  => This.Content (This.Position .. This.Position + 1));
-      This.Position := This.Position + 2;
+         These_Bytes  => This.Content (This.Position .. This.Position + Int16_Size - 1));
+      This.Position := This.Position + Int16_Size;
    end Get_Int16;
 
    ----------------
@@ -114,11 +114,11 @@ is
          To_Bytes   => As_Two_Bytes);
 
    begin
-      Value := As_UInt16 (This.Content (This.Position .. This.Position + 1));
+      Value := As_UInt16 (This.Content (This.Position .. This.Position + UInt16_Size - 1));
       Lemma_Two_Bytes_Equal_UInt16
         (This_Numeric => Value,
-         These_Bytes  => This.Content (This.Position .. This.Position + 1));
-      This.Position := This.Position + 2;
+         These_Bytes  => This.Content (This.Position .. This.Position + UInt16_Size - 1));
+      This.Position := This.Position + UInt16_Size;
    end Get_UInt16;
 
    ---------------
@@ -136,11 +136,11 @@ is
          To_Bytes   => As_Four_Bytes);
 
    begin
-      Value := As_Int32 (This.Content (This.Position .. This.Position + 3));
+      Value := As_Int32 (This.Content (This.Position .. This.Position + Int32_Size - 1));
       Lemma_Four_Bytes_Equal_Int32
         (This_Numeric => Value,
-         These_Bytes  => This.Content (This.Position .. This.Position + 3));
-      This.Position := This.Position + 4;
+         These_Bytes  => This.Content (This.Position .. This.Position + Int32_Size - 1));
+      This.Position := This.Position + Int32_Size;
    end Get_Int32;
 
    ----------------
@@ -158,11 +158,11 @@ is
          To_Bytes   => As_Four_Bytes);
 
    begin
-      Value := As_UInt32 (This.Content (This.Position .. This.Position + 3));
+      Value := As_UInt32 (This.Content (This.Position .. This.Position + UInt32_Size - 1));
       Lemma_Four_Bytes_Equal_UInt32
         (This_Numeric => Value,
-         These_Bytes  => This.Content (This.Position .. This.Position + 3));
-      This.Position := This.Position + 4;
+         These_Bytes  => This.Content (This.Position .. This.Position + UInt32_Size - 1));
+      This.Position := This.Position + UInt32_Size;
    end Get_UInt32;
 
    ----------------
@@ -184,10 +184,10 @@ is
          To_Bytes   => As_Four_Bytes);
 
    begin
-      Value := As_UInt32 (This.Content (First .. First + 3));
+      Value := As_UInt32 (This.Content (First .. First + UInt32_Size - 1));
       Lemma_Four_Bytes_Equal_UInt32
         (This_Numeric => Value,
-         These_Bytes  => This.Content (First .. First + 3));
+         These_Bytes  => This.Content (First .. First + UInt32_Size - 1));
    end Get_UInt32;
 
    ---------------
@@ -205,11 +205,11 @@ is
          To_Bytes   => As_Eight_Bytes);
 
    begin
-      Value := As_Int64 (This.Content (This.Position .. This.Position + 7));
+      Value := As_Int64 (This.Content (This.Position .. This.Position + Int64_Size - 1));
       Lemma_Eight_Bytes_Equal_Int64
         (This_Numeric => Value,
-         These_Bytes  => This.Content (This.Position .. This.Position + 7));
-      This.Position := This.Position + 8;
+         These_Bytes  => This.Content (This.Position .. This.Position + Int64_Size - 1));
+      This.Position := This.Position + Int64_Size;
    end Get_Int64;
 
    ----------------
@@ -227,11 +227,11 @@ is
          To_Bytes   => As_Eight_Bytes);
 
    begin
-      Value := As_UInt64 (This.Content (This.Position .. This.Position + 7));
+      Value := As_UInt64 (This.Content (This.Position .. This.Position + UInt64_Size - 1));
       Lemma_Eight_Bytes_Equal_UInt64
         (This_Numeric => Value,
-         These_Bytes  => This.Content (This.Position .. This.Position + 7));
-      This.Position := This.Position + 8;
+         These_Bytes  => This.Content (This.Position .. This.Position + UInt64_Size - 1));
+      This.Position := This.Position + UInt64_Size;
    end Get_UInt64;
 
    ---------------
@@ -266,13 +266,13 @@ is
       --  floating-point type, to ensure the compiler does not see the byte
       --  swapping (in the As_UInt32 instance) as producing an invalid
       --  floating-point value.
-      Value := As_Real32 (This.Content (This.Position .. This.Position + 3));
+      Value := As_Real32 (This.Content (This.Position .. This.Position + Real32_Size - 1));
 
       Lemma_Four_Bytes_Equal_Real32
         (This_Numeric => Value,
-         These_Bytes  => This.Content (This.Position .. This.Position + 3));
+         These_Bytes  => This.Content (This.Position .. This.Position + Real32_Size - 1));
 
-      This.Position := This.Position + 4;
+      This.Position := This.Position + Real32_Size;
    end Get_Real32;
 
    ----------------
@@ -307,13 +307,13 @@ is
       -- floating-point type, to ensure the compiler does not see the byte
       -- swapping (in the As_UInt64 instance) as producing an invalid
       -- floating-point value.
-      Value := As_Real64 (This.Content (This.Position .. This.Position + 7));
+      Value := As_Real64 (This.Content (This.Position .. This.Position + Real64_Size - 1));
 
       Lemma_Eight_Bytes_Equal_Real64
         (This_Numeric => Value,
-         These_Bytes  => This.Content (This.Position .. This.Position + 7));
+         These_Bytes  => This.Content (This.Position .. This.Position + Real64_Size - 1));
 
-      This.Position := This.Position + 8;
+      This.Position := This.Position + Real64_Size;
    end Get_Real64;
 
    ----------------
@@ -325,7 +325,6 @@ is
       Last          : out Integer;
       Stored_Length : out UInt32)
    is
-      Result : System.Address with Unreferenced;
    begin
       This.Get_UInt16 (UInt16 (Stored_Length));
       if Index (Stored_Length) > Remaining (This) then
@@ -381,8 +380,8 @@ is
    procedure Put_Byte (This : in out ByteBuffer'Class; Value : Byte) is
    begin
       This.Content (This.Position) := Value;
-      This.Highest_Write_Pos := This.Highest_Write_Pos + 1;
-      This.Position := This.Position + 1;
+      This.Highest_Write_Pos := This.Highest_Write_Pos + Byte_Size;
+      This.Position := This.Position + Byte_Size;
    end Put_Byte;
 
    -----------------
@@ -392,8 +391,8 @@ is
    procedure Put_Boolean (This : in out ByteBuffer'Class; Value : Boolean) is
    begin
       This.Content (This.Position) := Boolean'Pos (Value);
-      This.Highest_Write_Pos := This.Highest_Write_Pos + 1;
-      This.Position := This.Position + 1;
+      This.Highest_Write_Pos := This.Highest_Write_Pos + Boolean_Size;
+      This.Position := This.Position + Boolean_Size;
    end Put_Boolean;
 
    ---------------
@@ -402,9 +401,9 @@ is
 
    procedure Put_Int16 (This : in out ByteBuffer'Class; Value : Int16) is
    begin
-      This.Content (This.Position .. This.Position + 1) := As_Two_Bytes (Value);
-      This.Highest_Write_Pos := This.Highest_Write_Pos + 2;
-      This.Position := This.Position + 2;
+      This.Content (This.Position .. This.Position + Int16_Size - 1) := As_Two_Bytes (Value);
+      This.Highest_Write_Pos := This.Highest_Write_Pos + Int16_Size;
+      This.Position := This.Position + Int16_Size;
    end Put_Int16;
 
    ----------------
@@ -413,9 +412,9 @@ is
 
    procedure Put_UInt16 (This : in out ByteBuffer'Class; Value : UInt16) is
    begin
-      This.Content (This.Position .. This.Position + 1) := As_Two_Bytes (Value);
-      This.Highest_Write_Pos := This.Highest_Write_Pos + 2;
-      This.Position := This.Position + 2;
+      This.Content (This.Position .. This.Position + UInt16_Size - 1) := As_Two_Bytes (Value);
+      This.Highest_Write_Pos := This.Highest_Write_Pos + UInt16_Size;
+      This.Position := This.Position + UInt16_Size;
    end Put_UInt16;
 
    ---------------
@@ -424,9 +423,9 @@ is
 
    procedure Put_Int32 (This : in out ByteBuffer'Class; Value : Int32) is
    begin
-      This.Content (This.Position .. This.Position + 3) := As_Four_Bytes (Value);
-      This.Highest_Write_Pos := This.Highest_Write_Pos + 4;
-      This.Position := This.Position + 4;
+      This.Content (This.Position .. This.Position + Int32_Size - 1) := As_Four_Bytes (Value);
+      This.Highest_Write_Pos := This.Highest_Write_Pos + Int32_Size;
+      This.Position := This.Position + Int32_Size;
    end Put_Int32;
 
    ----------------
@@ -435,9 +434,9 @@ is
 
    procedure Put_UInt32 (This : in out ByteBuffer'Class; Value : UInt32) is
    begin
-      This.Content (This.Position .. This.Position + 3) := As_Four_Bytes (Value);
-      This.Highest_Write_Pos := This.Highest_Write_Pos + 4;
-      This.Position := This.Position + 4;
+      This.Content (This.Position .. This.Position + UInt32_Size - 1) := As_Four_Bytes (Value);
+      This.Highest_Write_Pos := This.Highest_Write_Pos + UInt32_Size;
+      This.Position := This.Position + UInt32_Size;
    end Put_UInt32;
 
    ---------------
@@ -446,9 +445,9 @@ is
 
    procedure Put_Int64 (This : in out ByteBuffer'Class; Value : Int64) is
    begin
-      This.Content (This.Position .. This.Position + 7) := As_Eight_Bytes (Value);
-      This.Highest_Write_Pos := This.Highest_Write_Pos + 8;
-      This.Position := This.Position + 8;
+      This.Content (This.Position .. This.Position + Int64_Size - 1) := As_Eight_Bytes (Value);
+      This.Highest_Write_Pos := This.Highest_Write_Pos + Int64_Size;
+      This.Position := This.Position + Int64_Size;
    end Put_Int64;
 
    ----------------
@@ -457,9 +456,9 @@ is
 
    procedure Put_UInt64 (This : in out ByteBuffer'Class; Value : UInt64) is
    begin
-      This.Content (This.Position .. This.Position + 7) := As_Eight_Bytes (Value);
-      This.Highest_Write_Pos := This.Highest_Write_Pos + 8;
-      This.Position := This.Position + 8;
+      This.Content (This.Position .. This.Position + UInt64_Size - 1) := As_Eight_Bytes (Value);
+      This.Highest_Write_Pos := This.Highest_Write_Pos + UInt64_Size;
+      This.Position := This.Position + UInt64_Size;
    end Put_UInt64;
 
    ----------------
@@ -468,9 +467,9 @@ is
 
    procedure Put_Real32 (This : in out ByteBuffer'Class; Value : Real32) is
    begin
-      This.Content (This.Position .. This.Position + 3) := As_Four_Bytes (Value);
-      This.Highest_Write_Pos := This.Highest_Write_Pos + 4;
-      This.Position := This.Position + 4;
+      This.Content (This.Position .. This.Position + Real32_Size - 1) := As_Four_Bytes (Value);
+      This.Highest_Write_Pos := This.Highest_Write_Pos + Real32_Size;
+      This.Position := This.Position + Real32_Size;
   end Put_Real32;
 
    ----------------
@@ -479,9 +478,9 @@ is
 
    procedure Put_Real64 (This : in out ByteBuffer'Class; Value : Real64) is
    begin
-      This.Content (This.Position .. This.Position + 7) := As_Eight_Bytes (Value);
-      This.Highest_Write_Pos := This.Highest_Write_Pos + 8;
-      This.Position := This.Position + 8;
+      This.Content (This.Position .. This.Position + Real64_Size - 1) := As_Eight_Bytes (Value);
+      This.Highest_Write_Pos := This.Highest_Write_Pos + Real64_Size;
+      This.Position := This.Position + Real64_Size;
   end Put_Real64;
 
    ----------------

--- a/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers.adb
+++ b/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers.adb
@@ -11,7 +11,7 @@ is
    -- Raw_Bytes_As_String --
    -------------------------
 
-   function Raw_Bytes_As_String (This : ByteBuffer'Class) return String is
+   function Raw_Bytes_As_String (This : ByteBuffer) return String is
       Length : constant Natural := Natural (This.Highest_Write_Pos);  -- safe due to precondition
       Result : String (1 .. Length);
    begin
@@ -25,7 +25,7 @@ is
    -- Rewind --
    ------------
 
-   procedure Rewind (This : in out ByteBuffer'Class) is
+   procedure Rewind (This : in out ByteBuffer) is
    begin
       This.Position := 0;
    end Rewind;
@@ -34,7 +34,7 @@ is
    -- Reset --
    -----------
 
-   procedure Reset (This : in out ByteBuffer'Class) is
+   procedure Reset (This : in out ByteBuffer) is
    begin
       Rewind (This);
       This.Highest_Write_Pos := 0;
@@ -44,7 +44,7 @@ is
    -- Checksum --
    --------------
 
-   function Checksum (This : ByteBuffer'Class;  Last : Index) return UInt32 is
+   function Checksum (This : ByteBuffer;  Last : Index) return UInt32 is
       Result : UInt32 := 0;
    begin
       for K in Index range This.Content'First .. Last loop
@@ -61,7 +61,7 @@ is
    -- Get_Byte --
    --------------
 
-   procedure Get_Byte (This : in out ByteBuffer'Class; Value : out Byte) is
+   procedure Get_Byte (This : in out ByteBuffer; Value : out Byte) is
    begin
       Value := This.Content (This.Position);
       This.Position := This.Position + Byte_Size;
@@ -71,7 +71,7 @@ is
    -- Get_Boolean --
    -----------------
 
-   procedure Get_Boolean (This : in out ByteBuffer'Class; Value : out Boolean) is
+   procedure Get_Boolean (This : in out ByteBuffer; Value : out Boolean) is
    begin
       Value := This.Content (This.Position) /= 0;
       This.Position := This.Position + Boolean_Size;
@@ -81,7 +81,7 @@ is
    -- Get_Int16 --
    ---------------
 
-   procedure Get_Int16 (This : in out ByteBuffer'Class; Value : out Int16) is
+   procedure Get_Int16 (This : in out ByteBuffer; Value : out Int16) is
 
      procedure Lemma_Two_Bytes_Equal_Int16 is new Lemma_Conversion_Equality
         (Numeric    => Int16,
@@ -103,7 +103,7 @@ is
    -- Get_UInt16 --
    ----------------
 
-   procedure Get_UInt16 (This : in out ByteBuffer'Class; Value : out UInt16) is
+   procedure Get_UInt16 (This : in out ByteBuffer; Value : out UInt16) is
 
      procedure Lemma_Two_Bytes_Equal_UInt16 is new Lemma_Conversion_Equality
         (Numeric    => UInt16,
@@ -125,7 +125,7 @@ is
    -- Get_Int32 --
    ---------------
 
-   procedure Get_Int32 (This : in out ByteBuffer'Class; Value : out Int32) is
+   procedure Get_Int32 (This : in out ByteBuffer; Value : out Int32) is
 
      procedure Lemma_Four_Bytes_Equal_Int32 is new Lemma_Conversion_Equality
         (Numeric    => Int32,
@@ -147,7 +147,7 @@ is
    -- Get_UInt32 --
    ----------------
 
-   procedure Get_UInt32 (This : in out ByteBuffer'Class; Value : out UInt32) is
+   procedure Get_UInt32 (This : in out ByteBuffer; Value : out UInt32) is
 
      procedure Lemma_Four_Bytes_Equal_UInt32 is new Lemma_Conversion_Equality
         (Numeric    => UInt32,
@@ -170,7 +170,7 @@ is
    ----------------
 
    procedure Get_UInt32
-     (This  : ByteBuffer'Class;
+     (This  : ByteBuffer;
       Value : out UInt32;
       First : Index)
    is
@@ -194,7 +194,7 @@ is
    -- Get_Int64 --
    ---------------
 
-   procedure Get_Int64 (This : in out ByteBuffer'Class; Value : out Int64) is
+   procedure Get_Int64 (This : in out ByteBuffer; Value : out Int64) is
 
      procedure Lemma_Eight_Bytes_Equal_Int64 is new Lemma_Conversion_Equality
         (Numeric    => Int64,
@@ -216,7 +216,7 @@ is
    -- Get_UInt64 --
    ----------------
 
-   procedure Get_UInt64 (This : in out ByteBuffer'Class; Value : out UInt64) is
+   procedure Get_UInt64 (This : in out ByteBuffer; Value : out UInt64) is
 
      procedure Lemma_Eight_Bytes_Equal_UInt64 is new Lemma_Conversion_Equality
         (Numeric    => UInt64,
@@ -238,7 +238,7 @@ is
    -- Get_Real32 --
    ---------------
 
-   procedure Get_Real32 (This : in out ByteBuffer'Class; Value : out Real32) is
+   procedure Get_Real32 (This : in out ByteBuffer; Value : out Real32) is
 
       function To_Real32 is new Ada.Unchecked_Conversion (Source => UInt32, Target => Real32);
       pragma Annotate
@@ -279,7 +279,7 @@ is
    -- Get_Real64 --
    ----------------
 
-   procedure Get_Real64 (This : in out ByteBuffer'Class; Value : out Real64) is
+   procedure Get_Real64 (This : in out ByteBuffer; Value : out Real64) is
 
       function To_Real64 is new Ada.Unchecked_Conversion (Source => UInt64, Target => Real64);
       pragma Annotate
@@ -320,13 +320,13 @@ is
    -- Get_String --
    ----------------
    procedure Get_String
-     (This          : in out ByteBuffer'Class;
+     (This          : in out ByteBuffer;
       Value         : in out String;
       Last          : out Integer;
       Stored_Length : out UInt32)
    is
    begin
-      This.Get_UInt16 (UInt16 (Stored_Length));
+      Get_UInt16 (This, UInt16 (Stored_Length));
       if Index (Stored_Length) > Remaining (This) then
          --  We don't have that many bytes logically remaining in the buffer
          --  to be consumed. Some corruption of the message has occurred.
@@ -355,12 +355,12 @@ is
    --------------------------
 
    procedure Get_Unbounded_String
-     (This          : in out ByteBuffer'Class;
+     (This          : in out ByteBuffer;
       Value         : out Unbounded_String;
       Stored_Length : out UInt32)
    is
    begin
-      This.Get_UInt16 (UInt16 (Stored_Length));
+      Get_UInt16 (This, UInt16 (Stored_Length));
       if Stored_Length > Max_String_Length or else
          Index (Stored_Length) > Remaining (This) or else
          This.Position + Index (Stored_length) > This.Highest_Write_Pos
@@ -377,7 +377,7 @@ is
    -- Put_Byte --
    --------------
 
-   procedure Put_Byte (This : in out ByteBuffer'Class; Value : Byte) is
+   procedure Put_Byte (This : in out ByteBuffer; Value : Byte) is
    begin
       This.Content (This.Position) := Value;
       This.Highest_Write_Pos := This.Highest_Write_Pos + Byte_Size;
@@ -388,7 +388,7 @@ is
    -- Put_Boolean --
    -----------------
 
-   procedure Put_Boolean (This : in out ByteBuffer'Class; Value : Boolean) is
+   procedure Put_Boolean (This : in out ByteBuffer; Value : Boolean) is
    begin
       This.Content (This.Position) := Boolean'Pos (Value);
       This.Highest_Write_Pos := This.Highest_Write_Pos + Boolean_Size;
@@ -399,7 +399,7 @@ is
    -- Put_Int16 --
    ---------------
 
-   procedure Put_Int16 (This : in out ByteBuffer'Class; Value : Int16) is
+   procedure Put_Int16 (This : in out ByteBuffer; Value : Int16) is
    begin
       This.Content (This.Position .. This.Position + Int16_Size - 1) := As_Two_Bytes (Value);
       This.Highest_Write_Pos := This.Highest_Write_Pos + Int16_Size;
@@ -410,7 +410,7 @@ is
    -- Put_UInt16 --
    ----------------
 
-   procedure Put_UInt16 (This : in out ByteBuffer'Class; Value : UInt16) is
+   procedure Put_UInt16 (This : in out ByteBuffer; Value : UInt16) is
    begin
       This.Content (This.Position .. This.Position + UInt16_Size - 1) := As_Two_Bytes (Value);
       This.Highest_Write_Pos := This.Highest_Write_Pos + UInt16_Size;
@@ -421,7 +421,7 @@ is
    -- Put_Int32 --
    ---------------
 
-   procedure Put_Int32 (This : in out ByteBuffer'Class; Value : Int32) is
+   procedure Put_Int32 (This : in out ByteBuffer; Value : Int32) is
    begin
       This.Content (This.Position .. This.Position + Int32_Size - 1) := As_Four_Bytes (Value);
       This.Highest_Write_Pos := This.Highest_Write_Pos + Int32_Size;
@@ -432,7 +432,7 @@ is
    -- Put_UInt32 --
    ----------------
 
-   procedure Put_UInt32 (This : in out ByteBuffer'Class; Value : UInt32) is
+   procedure Put_UInt32 (This : in out ByteBuffer; Value : UInt32) is
    begin
       This.Content (This.Position .. This.Position + UInt32_Size - 1) := As_Four_Bytes (Value);
       This.Highest_Write_Pos := This.Highest_Write_Pos + UInt32_Size;
@@ -443,7 +443,7 @@ is
    -- Put_Int64 --
    ---------------
 
-   procedure Put_Int64 (This : in out ByteBuffer'Class; Value : Int64) is
+   procedure Put_Int64 (This : in out ByteBuffer; Value : Int64) is
    begin
       This.Content (This.Position .. This.Position + Int64_Size - 1) := As_Eight_Bytes (Value);
       This.Highest_Write_Pos := This.Highest_Write_Pos + Int64_Size;
@@ -454,7 +454,7 @@ is
    -- Put_UInt64 --
    ----------------
 
-   procedure Put_UInt64 (This : in out ByteBuffer'Class; Value : UInt64) is
+   procedure Put_UInt64 (This : in out ByteBuffer; Value : UInt64) is
    begin
       This.Content (This.Position .. This.Position + UInt64_Size - 1) := As_Eight_Bytes (Value);
       This.Highest_Write_Pos := This.Highest_Write_Pos + UInt64_Size;
@@ -465,7 +465,7 @@ is
    -- Put_Real32 --
    ----------------
 
-   procedure Put_Real32 (This : in out ByteBuffer'Class; Value : Real32) is
+   procedure Put_Real32 (This : in out ByteBuffer; Value : Real32) is
    begin
       This.Content (This.Position .. This.Position + Real32_Size - 1) := As_Four_Bytes (Value);
       This.Highest_Write_Pos := This.Highest_Write_Pos + Real32_Size;
@@ -476,7 +476,7 @@ is
    -- Put_Real64 --
    ----------------
 
-   procedure Put_Real64 (This : in out ByteBuffer'Class; Value : Real64) is
+   procedure Put_Real64 (This : in out ByteBuffer; Value : Real64) is
    begin
       This.Content (This.Position .. This.Position + Real64_Size - 1) := As_Eight_Bytes (Value);
       This.Highest_Write_Pos := This.Highest_Write_Pos + Real64_Size;
@@ -487,15 +487,15 @@ is
    -- Put_String --
    ----------------
 
-   procedure Put_String (This : in out ByteBuffer'Class;  Value : String) is
+   procedure Put_String (This : in out ByteBuffer;  Value : String) is
    begin
       --  We need to insert the length in any case, including when zero, so that
       --  the deserialization routine will have a length to read. That routine
       --  will then read that many bytes, so a zero length will work on that
       --  side.
-      This.Put_UInt16 (Value'Length);
+      Put_UInt16 (This, Value'Length);
       if Value'Length > 0 then
-         This.Put_Raw_Bytes (Value);
+         Put_Raw_Bytes (This, Value);
       end if;
    end Put_String;
 
@@ -503,7 +503,7 @@ is
    -- Put_Raw_Bytes --
    -------------------
 
-   procedure Put_Raw_Bytes (This : in out ByteBuffer'Class; Value : String) is
+   procedure Put_Raw_Bytes (This : in out ByteBuffer; Value : String) is
    begin
       if Value'Length > 0 then
          Copy_String_To_Buffer (This, From => Value);
@@ -514,7 +514,7 @@ is
    -- Put_Raw_Bytes --
    -------------------
 
-   procedure Put_Raw_Bytes (This : in out ByteBuffer'Class; Value : Byte_Array) is
+   procedure Put_Raw_Bytes (This : in out ByteBuffer; Value : Byte_Array) is
    begin
       if Value'Length > 0 then
          Copy_Bytes_To_Buffer (This, From => Value);
@@ -525,9 +525,9 @@ is
    -- Put_Unbounded_String --
    --------------------------
 
-   procedure Put_Unbounded_String (This : in out ByteBuffer'Class;  Value : Unbounded_String) is
+   procedure Put_Unbounded_String (This : in out ByteBuffer;  Value : Unbounded_String) is
    begin
-      This.Put_String (To_String (Value));
+      Put_String (This, To_String (Value));
    end Put_Unbounded_String;
 
 end AVTAS.LMCP.ByteBuffers;

--- a/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers.ads
+++ b/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers.ads
@@ -41,8 +41,9 @@ is
    --  back to 0 by a call to Reset.
 
    procedure Rewind (This : in out ByteBuffer'Class) with
-     Post => Position (This) = 0 and
-             High_Water_Mark (This) = High_Water_Mark (This)'Old;
+     Post => Position (This) = 0                                 and then
+             High_Water_Mark (This) = High_Water_Mark (This)'Old and then
+             Raw_Bytes (This) = Raw_Bytes (This)'Old;
    --  Rewinding the buffer position allows reading of existing content from
    --  the beginning, presumably after writing values into it (via the Put_*
    --  routines).
@@ -101,12 +102,13 @@ is
       Value : out UInt32;
       First : Index)
    with
-     Pre  => First <= This.Capacity      and then
-             High_Water_Mark (This) >= First + 3,
-     Post => Position (This) = Position (This)'Old                         and then
-             High_Water_Mark (This) = High_Water_Mark (This)'Old           and then
-             Remaining (This) = Remaining (This)'Old                       and then
-             Raw_Bytes (This) = Raw_Bytes (This)'Old;
+     Pre  => First <= This.Capacity - 3 and then
+             First + 3 <= High_Water_Mark (This) - 1,
+     Post => Position (This) = Position (This)'Old               and then
+             High_Water_Mark (This) = High_Water_Mark (This)'Old and then
+             Remaining (This) = Remaining (This)'Old             and then
+             Raw_Bytes (This) = Raw_Bytes (This)'Old             and then
+             Raw_Bytes (This) (First .. First + 3) = As_Four_Bytes (Value);
    --  Gets the four bytes comprising a UInt32 value from This buffer, starting
    --  at absolute index First (rather than from This.Position)
 
@@ -175,7 +177,6 @@ is
        Position (This) <= High_Water_Mark (This) - 2,
        --  The string content is preceded in the buffer by a two-byte length,
        --  even when the string length is zero (ie when the string is empty).
-
      Post =>
        High_Water_Mark (This) = High_Water_Mark (This)'Old and then
        Stored_Length <= Max_String_Length                  and then
@@ -355,8 +356,7 @@ is
    --  already. That also means that there is no two-byte length restriction.
 
    procedure Put_Raw_Bytes (This : in out ByteBuffer'Class; Value : String) with
-     Pre  => Value'Length <= Max_String_Length and then
-             Remaining (This) >= Value'Length  and then
+     Pre  => Remaining (This) >= Value'Length  and then
              High_Water_Mark (This) + Value'Length <= This.Capacity,
      Post => Position (This) = Position (This)'Old + Value'Length               and then
              High_Water_Mark (This) = High_Water_Mark (This)'Old + Value'Length and then
@@ -377,13 +377,13 @@ is
              Prior_Content_Unchanged (This, Old_Value => This'Old);
 
    function Raw_Bytes (This : ByteBuffer'Class) return Byte_Array;
-   --  Returns the internal byte array content, up to High_Water_Mark (This)
+   --  Returns the entire internal byte array content, up to High_Water_Mark (This)
 
-   function Raw_Bytes (This : ByteBuffer'Class) return String with
-     Post => Raw_Bytes'Result'First = 1 and then
-             Raw_Bytes'Result'Length = Index'Min (Max_String_Length, High_Water_Mark (This));
-   --  Returns the internal byte array content, up to High_Water_Mark (This),
-   --  as a String
+   function Raw_Bytes_As_String (This : ByteBuffer'Class) return String with
+     Pre  => High_Water_Mark (This) <= Index (Positive'Last),
+     Post => Raw_Bytes_As_String'Result'First = 1 and then
+             Raw_Bytes_As_String'Result'Length = High_Water_Mark (This);
+   --  Returns the entire internal byte array content, as a String
 
    function Checksum (This : ByteBuffer'Class;  Last : Index) return UInt32 with
      Pre => Last <= This.Capacity;
@@ -430,8 +430,7 @@ is
       Boolean
    with
      Ghost,
-     Pre => Comparand'Length <= Max_String_Length  and then
-            This.Capacity >= Comparand'Length      and then
+     Pre => This.Capacity >= Comparand'Length      and then
             Start <= Index'Last - Comparand'Length and then
             Start <= This.Capacity - Comparand'Length;
    --  Returns whether the slice of This, starting at Start, equals the
@@ -475,9 +474,7 @@ private
    ---------------
 
    function Raw_Bytes (This : ByteBuffer'Class) return Byte_Array is
-     (if This.Highest_Write_Pos > 0
-      then This.Content (0 .. This.Highest_Write_Pos - 1)
-      else This.Content (1 .. 0));
+      (This.Content (0 .. This.Highest_Write_Pos - 1));
 
    ---------------
    -- Remaining --

--- a/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers.ads
+++ b/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers.ads
@@ -24,23 +24,23 @@ is
 
    subtype NonZero_Index is Index range 1 .. Index'Last;
 
-   type ByteBuffer (Capacity : NonZero_Index) is tagged private with
+   type ByteBuffer (Capacity : NonZero_Index) is private with
      Default_Initial_Condition =>
        Position (ByteBuffer) = 0 and
        Remaining (ByteBuffer) = Capacity;
 
-   function Remaining (This : ByteBuffer'Class) return Index;
+   function Remaining (This : ByteBuffer) return Index;
    --  Returns the number of unused bytes remaining available in This
 
-   function Position (This : ByteBuffer'Class) return Index;
+   function Position (This : ByteBuffer) return Index;
    --  Returns the next place within This buffer for reading or writing
 
-   function High_Water_Mark (This : ByteBuffer'Class) return Index;
+   function High_Water_Mark (This : ByteBuffer) return Index;
    --  Returns the number of data bytes currently written into This buffer.
    --  This value is never decremented by a Get_* routine, and is only set
    --  back to 0 by a call to Reset.
 
-   procedure Rewind (This : in out ByteBuffer'Class) with
+   procedure Rewind (This : in out ByteBuffer) with
      Post => Position (This) = 0                                 and then
              High_Water_Mark (This) = High_Water_Mark (This)'Old and then
              Raw_Bytes (This) = Raw_Bytes (This)'Old;
@@ -48,7 +48,7 @@ is
    --  the beginning, presumably after writing values into it (via the Put_*
    --  routines).
 
-   procedure Reset (This : in out ByteBuffer'Class) with
+   procedure Reset (This : in out ByteBuffer) with
      Post => Position (This) = 0 and
              High_Water_Mark (This) = 0;
 
@@ -73,7 +73,7 @@ is
    --  string in a buffer is preceeded by the length of that string, even when
    --  the length is zero.
 
-   procedure Get_Byte (This : in out ByteBuffer'Class;  Value : out Byte) with
+   procedure Get_Byte (This : in out ByteBuffer;  Value : out Byte) with
      Pre  => Remaining (This) >= Byte_Size and then
              Position (This) <= High_Water_Mark (This) - Byte_Size,
      Post => Position (This) = Position (This)'Old + Byte_Size   and then
@@ -82,7 +82,7 @@ is
              Raw_Bytes (This) (Position (This)'Old) = Value      and then
              Prior_Content_Unchanged (This, This'Old);
 
-   procedure Get_Boolean (This : in out ByteBuffer'Class;  Value : out Boolean) with
+   procedure Get_Boolean (This : in out ByteBuffer;  Value : out Boolean) with
      Pre  => Remaining (This) >= Boolean_Size and then
              Position (This) <= High_Water_Mark (This) - Boolean_Size,
      Post => Position (This) = Position (This)'Old + Boolean_Size   and then
@@ -91,7 +91,7 @@ is
              (Raw_Bytes (This) (Position (This)'Old) /= 0) = Value  and then
              Prior_Content_Unchanged (This, This'Old);
 
-   procedure Get_Int16 (This : in out ByteBuffer'Class;  Value : out Int16) with
+   procedure Get_Int16 (This : in out ByteBuffer;  Value : out Int16) with
      Pre  => Remaining (This) >= Int16_Size and then
              Position (This) <= High_Water_Mark (This) - Int16_Size,
      Post => Position (This) = Position (This)'Old + Int16_Size   and then
@@ -100,7 +100,7 @@ is
              Raw_Bytes (This) (Position (This)'Old .. Position (This) - 1) = As_Two_Bytes (Value) and then
              Prior_Content_Unchanged (This, This'Old);
 
-   procedure Get_UInt16 (This : in out ByteBuffer'Class;  Value : out UInt16) with
+   procedure Get_UInt16 (This : in out ByteBuffer;  Value : out UInt16) with
      Pre  => Remaining (This) >= UInt16_Size and then
              Position (This) <= High_Water_Mark (This) - UInt16_Size,
      Post => Position (This) = Position (This)'Old + UInt16_Size   and then
@@ -109,7 +109,7 @@ is
              Raw_Bytes (This) (Position (This)'Old .. Position (This) - 1) = As_Two_Bytes (Value) and then
              Prior_Content_Unchanged (This, This'Old);
 
-   procedure Get_Int32 (This : in out ByteBuffer'Class;  Value : out Int32) with
+   procedure Get_Int32 (This : in out ByteBuffer;  Value : out Int32) with
      Pre  => Remaining (This) >= Int32_Size and then
              Position (This) <= High_Water_Mark (This) - Int32_Size,
      Post => Position (This) = Position (This)'Old + Int32_Size   and then
@@ -119,7 +119,7 @@ is
              Prior_Content_Unchanged (This, This'Old);
 
    procedure Get_UInt32
-     (This  : ByteBuffer'Class;
+     (This  : ByteBuffer;
       Value : out UInt32;
       First : Index)
    with
@@ -133,7 +133,7 @@ is
    --  Gets the four bytes comprising a UInt32 value from This buffer, starting
    --  at absolute index First (rather than from This.Position)
 
-   procedure Get_UInt32 (This : in out ByteBuffer'Class;  Value : out UInt32) with
+   procedure Get_UInt32 (This : in out ByteBuffer;  Value : out UInt32) with
      Pre  => Remaining (This) >= UInt32_Size and then
              Position (This) <= High_Water_Mark (This) - UInt32_Size,
      Post => Position (This) = Position (This)'Old + UInt32_Size   and then
@@ -142,7 +142,7 @@ is
              Raw_Bytes (This) (Position (This)'Old .. Position (This) - 1) = As_Four_Bytes (Value) and then
              Prior_Content_Unchanged (This, This'Old);
 
-   procedure Get_Int64  (This : in out ByteBuffer'Class;  Value : out Int64) with
+   procedure Get_Int64  (This : in out ByteBuffer;  Value : out Int64) with
      Pre  => Remaining (This) >= Int64_Size and then
              Position (This) <= High_Water_Mark (This) - Int64_Size,
      Post => Position (This) = Position (This)'Old + Int64_Size   and then
@@ -151,7 +151,7 @@ is
              Raw_Bytes (This) (Position (This)'Old .. Position (This) - 1) = As_Eight_Bytes (Value) and then
              Prior_Content_Unchanged (This, This'Old);
 
-   procedure Get_UInt64 (This : in out ByteBuffer'Class;  Value : out UInt64) with
+   procedure Get_UInt64 (This : in out ByteBuffer;  Value : out UInt64) with
      Pre  => Remaining (This) >= UInt64_Size and then
              Position (This) <= High_Water_Mark (This) - UInt64_Size,
      Post => Position (This) = Position (This)'Old + UInt64_Size   and then
@@ -160,7 +160,7 @@ is
              Raw_Bytes (This) (Position (This)'Old .. Position (This) - 1) = As_Eight_Bytes (Value) and then
              Prior_Content_Unchanged (This, This'Old);
 
-   procedure Get_Real32 (This : in out ByteBuffer'Class;  Value : out Real32) with
+   procedure Get_Real32 (This : in out ByteBuffer;  Value : out Real32) with
      Pre  => Remaining (This) >= Real32_Size and then
              Position (This) <= High_Water_Mark (This) - Real32_Size,
      Post => Position (This) = Position (This)'Old + Real32_Size   and then
@@ -169,7 +169,7 @@ is
              Raw_Bytes (This) (Position (This)'Old .. Position (This) - 1) = As_Four_Bytes (Value) and then
              Prior_Content_Unchanged (This, This'Old);
 
-   procedure Get_Real64 (This : in out ByteBuffer'Class;  Value : out Real64) with
+   procedure Get_Real64 (This : in out ByteBuffer;  Value : out Real64) with
      Pre  => Remaining (This) >= Real64_Size and then
              Position (This) <= High_Water_Mark (This) - Real64_Size,
      Post => Position (This) = Position (This)'Old + Real64_Size   and then
@@ -179,7 +179,7 @@ is
              Prior_Content_Unchanged (This, This'Old);
 
    procedure Get_String
-     (This          : in out ByteBuffer'Class;
+     (This          : in out ByteBuffer;
       Value         : in out String;
       Last          : out Integer;
       Stored_Length : out UInt32)
@@ -228,7 +228,7 @@ is
                   Value (Value'First .. Last)));
 
    procedure Get_Unbounded_String
-     (This          : in out ByteBuffer'Class;
+     (This          : in out ByteBuffer;
       Value         : out Unbounded_String;
       Stored_Length : out UInt32)
    with
@@ -251,7 +251,7 @@ is
                  Equal (Raw_Bytes (This) (Position (This)'Old + Stored_Length_Size .. Position (This) - 1),
                         To_String (Value)));
 
-   procedure Put_Byte (This : in out ByteBuffer'Class;  Value : Byte) with
+   procedure Put_Byte (This : in out ByteBuffer;  Value : Byte) with
      Pre  => Remaining (This) >= Byte_Size and then
              High_Water_Mark (This) <= This.Capacity - Byte_Size,
      Post => Position (This) = Position (This)'Old + Byte_Size               and then
@@ -260,7 +260,7 @@ is
              Raw_Bytes (This) (Position (This)'Old) = Value                  and then
              Prior_Content_Unchanged (This, This'Old);
 
-   procedure Put_Boolean (This : in out ByteBuffer'Class;  Value : Boolean) with
+   procedure Put_Boolean (This : in out ByteBuffer;  Value : Boolean) with
      Pre  => Remaining (This) >= Boolean_Size and then
              High_Water_Mark (This) <= This.Capacity - Boolean_Size,
      Post => Position (This) = Position (This)'Old + Boolean_Size               and then
@@ -269,7 +269,7 @@ is
              Raw_Bytes (This) (Position (This)'Old) = Boolean'Pos (Value)       and then
              Prior_Content_Unchanged (This, This'Old);
 
-   procedure Put_Int16 (This : in out ByteBuffer'Class;  Value : Int16) with
+   procedure Put_Int16 (This : in out ByteBuffer;  Value : Int16) with
      Pre  => Remaining (This) >= Int16_Size and then
              High_Water_Mark (This) <= This.Capacity - Int16_Size,
      Post => Position (This) = Position (This)'Old + Int16_Size               and then
@@ -278,7 +278,7 @@ is
              Raw_Bytes (This) (Position (This)'Old .. Position (This) - 1) = As_Two_Bytes (Value) and then
              Prior_Content_Unchanged (This, This'Old);
 
-   procedure Put_UInt16 (This : in out ByteBuffer'Class;  Value : UInt16) with
+   procedure Put_UInt16 (This : in out ByteBuffer;  Value : UInt16) with
      Pre  => Remaining (This) >= UInt16_Size and then
              High_Water_Mark (This) <= This.Capacity - UInt16_Size,
      Post => Position (This) = Position (This)'Old + UInt16_Size               and then
@@ -287,7 +287,7 @@ is
              Raw_Bytes (This) (Position (This)'Old .. Position (This) - 1) = As_Two_Bytes (Value) and then
              Prior_Content_Unchanged (This, This'Old);
 
-   procedure Put_Int32 (This : in out ByteBuffer'Class;  Value : Int32) with
+   procedure Put_Int32 (This : in out ByteBuffer;  Value : Int32) with
      Pre  => Remaining (This) >= Int32_Size and then
              High_Water_Mark (This) <= This.Capacity - Int32_Size,
      Post => Position (This) = Position (This)'Old + Int32_Size               and then
@@ -296,7 +296,7 @@ is
              Raw_Bytes (This) (Position (This)'Old .. Position (This) - 1) = As_Four_Bytes (Value) and then
              Prior_Content_Unchanged (This, This'Old);
 
-   procedure Put_UInt32 (This : in out ByteBuffer'Class;  Value : UInt32) with
+   procedure Put_UInt32 (This : in out ByteBuffer;  Value : UInt32) with
      Pre  => Remaining (This) >= UInt32_Size and then
              High_Water_Mark (This) <= This.Capacity - UInt32_Size,
      Post => Position (This) = Position (This)'Old + UInt32_Size               and then
@@ -305,7 +305,7 @@ is
              Raw_Bytes (This) (Position (This)'Old .. Position (This) - 1) = As_Four_Bytes (Value) and then
              Prior_Content_Unchanged (This, This'Old);
 
-   procedure Put_Int64 (This : in out ByteBuffer'Class;  Value : Int64) with
+   procedure Put_Int64 (This : in out ByteBuffer;  Value : Int64) with
      Pre  => Remaining (This) >= Int64_Size and then
              High_Water_Mark (This) <= This.Capacity - Int64_Size,
      Post => Position (This) = Position (This)'Old + Int64_Size               and then
@@ -314,7 +314,7 @@ is
              Raw_Bytes (This) (Position (This)'Old .. Position (This) - 1) = As_Eight_Bytes (Value) and then
              Prior_Content_Unchanged (This, This'Old);
 
-   procedure Put_UInt64 (This : in out ByteBuffer'Class;  Value : UInt64) with
+   procedure Put_UInt64 (This : in out ByteBuffer;  Value : UInt64) with
      Pre  => Remaining (This) >= UInt64_Size and then
              High_Water_Mark (This) <= This.Capacity - UInt64_Size,
      Post => Position (This) = Position (This)'Old + UInt64_Size               and then
@@ -323,7 +323,7 @@ is
              Raw_Bytes (This) (Position (This)'Old .. Position (This) - 1) = As_Eight_Bytes (Value) and then
              Prior_Content_Unchanged (This, This'Old);
 
-   procedure Put_Real32 (This : in out ByteBuffer'Class;  Value : Real32) with
+   procedure Put_Real32 (This : in out ByteBuffer;  Value : Real32) with
      Pre  => Remaining (This) >= Real32_Size and then
              High_Water_Mark (This) <= This.Capacity - Real32_Size,
      Post => Position (This) = Position (This)'Old + Real32_Size               and then
@@ -332,7 +332,7 @@ is
              Raw_Bytes (This) (Position (This)'Old .. Position (This) - 1) = As_Four_Bytes (Value) and then
              Prior_Content_Unchanged (This, This'Old);
 
-   procedure Put_Real64 (This : in out ByteBuffer'Class;  Value : Real64) with
+   procedure Put_Real64 (This : in out ByteBuffer;  Value : Real64) with
      Pre  => Remaining (This) >= Real64_Size and then
              High_Water_Mark (This) <= This.Capacity - Real64_Size,
      Post => Position (This) = Position (This)'Old + Real64_Size               and then
@@ -341,7 +341,7 @@ is
              Raw_Bytes (This) (Position (This)'Old .. Position (This) - 1) = As_Eight_Bytes (Value) and then
              Prior_Content_Unchanged (This, This'Old);
 
-   procedure Put_String (This : in out ByteBuffer'Class;  Value : String) with
+   procedure Put_String (This : in out ByteBuffer;  Value : String) with
      Pre  => Value'First = 1                      and then
              Value'Length <= Max_String_Length    and then
              Remaining (This) >= Value'Length + Stored_Length_Size and then
@@ -349,17 +349,17 @@ is
      Post => Position (This) = Position (This)'Old + Value'Length + Stored_Length_Size               and then
              High_Water_Mark (This) = High_Water_Mark (This)'Old + Value'Length + Stored_Length_Size and then
              Remaining (This) = Remaining (This)'Old - Value'Length - Stored_Length_Size             and then
-             New_Content_Equal (This, This.Position'Old + Stored_Length_Size, Value)                 and then
+             New_Content_Equal (This, Position (This)'Old + Stored_Length_Size, Value)                 and then
              Prior_Content_Unchanged (This, Old_Value => This'Old);
 
-   procedure Put_Unbounded_String (This : in out ByteBuffer'Class; Value : Unbounded_String) with
+   procedure Put_Unbounded_String (This : in out ByteBuffer; Value : Unbounded_String) with
      Pre  => Length (Value) <= Max_String_Length and then
              Remaining (This) >= Index (Length (Value)) + Stored_Length_Size and then
              High_Water_Mark (This) <= This.Capacity - Index (Length (Value)) - Stored_Length_Size,
      Post => Position (This) = Position (This)'Old + Index (Length (Value)) + Stored_Length_Size               and then
              High_Water_Mark (This) = High_Water_Mark (This)'Old + Index (Length (Value)) + Stored_Length_Size and then
              Remaining (This) = Remaining (This)'Old - Index (Length (Value)) - Stored_Length_Size             and then
-             New_Content_Equal (This, This.Position'Old + Stored_Length_Size, To_String (Value))               and then
+             New_Content_Equal (This, Position (This)'Old + Stored_Length_Size, To_String (Value))               and then
              Prior_Content_Unchanged (This, Old_Value => This'Old);
 
    --  The following two Put_Raw_Bytes routines populate the ByteBuffer from
@@ -372,37 +372,37 @@ is
    --  the content of the input string is an encoded (serialized) message
    --  already. That also means that there is no two-byte length restriction.
 
-   procedure Put_Raw_Bytes (This : in out ByteBuffer'Class; Value : String) with
+   procedure Put_Raw_Bytes (This : in out ByteBuffer; Value : String) with
      Pre  => Remaining (This) >= Value'Length  and then
              High_Water_Mark (This) + Value'Length <= This.Capacity,
      Post => Position (This) = Position (This)'Old + Value'Length               and then
              High_Water_Mark (This) = High_Water_Mark (This)'Old + Value'Length and then
              Remaining (This) = Remaining (This)'Old - Value'Length             and then
-             New_Content_Equal (This, This.Position'Old, Value)                 and then
+             New_Content_Equal (This, Position (This)'Old, Value)                 and then
              Prior_Content_Unchanged (This, Old_Value => This'Old);
 
    type Byte_Array is array (Index range <>) of aliased Byte with
      Component_Size => Byte'Size;
 
-   procedure Put_Raw_Bytes (This : in out ByteBuffer'Class; Value : Byte_Array) with
+   procedure Put_Raw_Bytes (This : in out ByteBuffer; Value : Byte_Array) with
      Pre  => Remaining (This) >= Value'Length and then
              High_Water_Mark (This) + Value'Length <= This.Capacity,
      Post => Position (This) = Position (This)'Old + Value'Length               and then
              High_Water_Mark (This) = High_Water_Mark (This)'Old + Value'Length and then
              Remaining (This) = Remaining (This)'Old - Value'Length             and then
-             New_Content_Equal (This, This.Position'Old, Value)                 and then
+             New_Content_Equal (This, Position (This)'Old, Value)                 and then
              Prior_Content_Unchanged (This, Old_Value => This'Old);
 
-   function Raw_Bytes (This : ByteBuffer'Class) return Byte_Array;
+   function Raw_Bytes (This : ByteBuffer) return Byte_Array;
    --  Returns the entire internal byte array content, up to High_Water_Mark (This)
 
-   function Raw_Bytes_As_String (This : ByteBuffer'Class) return String with
+   function Raw_Bytes_As_String (This : ByteBuffer) return String with
      Pre  => High_Water_Mark (This) <= Index (Positive'Last),
      Post => Raw_Bytes_As_String'Result'First = 1 and then
              Raw_Bytes_As_String'Result'Length = High_Water_Mark (This);
    --  Returns the entire internal byte array content, as a String
 
-   function Checksum (This : ByteBuffer'Class;  Last : Index) return UInt32 with
+   function Checksum (This : ByteBuffer;  Last : Index) return UInt32 with
      Pre => Last <= This.Capacity;
    --  Computes the checksum of the slice of the internal byte array from the
    --  first byte up to Last
@@ -434,13 +434,13 @@ is
    --  Ghost routines  --
    ----------------------
 
-   function Prior_Content_Unchanged (New_Value, Old_Value : ByteBuffer'Class) return Boolean with
+   function Prior_Content_Unchanged (New_Value, Old_Value : ByteBuffer) return Boolean with
      Ghost,
      Pre  => New_Value.Capacity = Old_Value.Capacity;
    --  Returns whether the content of Old_Value was unchanged in New_Value
 
    function New_Content_Equal
-     (This      : ByteBuffer'Class;
+     (This      : ByteBuffer;
       Start     : Index;
       Comparand : String)
    return
@@ -454,7 +454,7 @@ is
    --  Comparand of type String
 
    function New_Content_Equal
-     (This      : ByteBuffer'Class;
+     (This      : ByteBuffer;
       Start     : Index;
       Comparand : Byte_Array)
    return
@@ -477,7 +477,7 @@ is
 
 private
 
-   type ByteBuffer (Capacity : NonZero_Index) is tagged record
+   type ByteBuffer (Capacity : NonZero_Index) is record
       Content           : Byte_Array (0 .. Capacity) := (others => 0);
       Position          : Index := 0;
       Highest_Write_Pos : Index := 0;
@@ -490,28 +490,28 @@ private
    -- Raw_Bytes --
    ---------------
 
-   function Raw_Bytes (This : ByteBuffer'Class) return Byte_Array is
+   function Raw_Bytes (This : ByteBuffer) return Byte_Array is
       (This.Content (0 .. This.Highest_Write_Pos - 1));
 
    ---------------
    -- Remaining --
    ---------------
 
-   function Remaining (This : ByteBuffer'Class) return Index is
+   function Remaining (This : ByteBuffer) return Index is
       (This.Capacity - This.Position);
 
    --------------
    -- Position --
    --------------
 
-   function Position (This : ByteBuffer'Class) return Index is
+   function Position (This : ByteBuffer) return Index is
      (This.Position);
 
    ---------------------
    -- High_Water_Mark --
    ---------------------
 
-   function High_Water_Mark (This : ByteBuffer'Class) return Index is
+   function High_Water_Mark (This : ByteBuffer) return Index is
      (This.Highest_Write_Pos);
 
    --------------------------------------------------------------------
@@ -749,7 +749,7 @@ private
    -- Prior_Content_Unchanged --
    -----------------------------
 
-   function Prior_Content_Unchanged (New_Value, Old_Value : ByteBuffer'Class) return Boolean is
+   function Prior_Content_Unchanged (New_Value, Old_Value : ByteBuffer) return Boolean is
      (if Old_Value.Position > 0 then  -- not empty, otherwise Unchanged'Result is trivially true
        (New_Value.Content (0 .. Old_Value.Position - 1) = Old_Value.Content (0 .. Old_Value.Position - 1)));
 
@@ -758,7 +758,7 @@ private
    -----------------------
 
    function New_Content_Equal
-     (This      : ByteBuffer'Class;
+     (This      : ByteBuffer;
       Start     : Index;
       Comparand : String)
    return
@@ -773,7 +773,7 @@ private
    -----------------------
 
    function New_Content_Equal
-     (This      : ByteBuffer'Class;
+     (This      : ByteBuffer;
       Start     : Index;
       Comparand : Byte_Array)
    return

--- a/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers.ads
+++ b/src/templates/ada/avtas/lmcp/avtas-lmcp-bytebuffers.ads
@@ -52,48 +52,69 @@ is
      Post => Position (This) = 0 and
              High_Water_Mark (This) = 0;
 
+   Byte_Size    : constant := 1;  -- bytes
+   Boolean_Size : constant := 1;  -- bytes
+   Int16_Size   : constant := 2;  -- bytes
+   UInt16_Size  : constant := 2;  -- bytes
+   Int32_Size   : constant := 4;  -- bytes
+   UInt32_Size  : constant := 4;  -- bytes
+   Int64_Size   : constant := 8;  -- bytes
+   UInt64_Size  : constant := 8;  -- bytes
+   Real32_Size  : constant := 4;  -- bytes
+   Real64_Size  : constant := 8;  -- bytes
+
+   Max_String_Length : constant := UInt16'Last; -- ie, 65_535
+   --  Like the C++ version, this is as large as a serialized (stored) string
+   --  can be, because we write each string's length into the buffer as a
+   --  UInt16 during serialization.
+
+   Stored_Length_Size : constant := UInt16_Size;
+   --  The size in bytes for the lengths of strings stored in buffers. Every
+   --  string in a buffer is preceeded by the length of that string, even when
+   --  the length is zero.
+
    procedure Get_Byte (This : in out ByteBuffer'Class;  Value : out Byte) with
-     Pre  => Remaining (This) >= 1 and then
-             Position (This) <= High_Water_Mark (This) - 1,
-     Post => Position (This) = Position (This)'Old + 1           and then
+     Pre  => Remaining (This) >= Byte_Size and then
+             Position (This) <= High_Water_Mark (This) - Byte_Size,
+     Post => Position (This) = Position (This)'Old + Byte_Size   and then
              High_Water_Mark (This) = High_Water_Mark (This)'Old and then
-             Remaining (This) + 1 = Remaining (This)'Old         and then
+             Remaining (This) + Byte_Size = Remaining (This)'Old and then
              Raw_Bytes (This) (Position (This)'Old) = Value      and then
              Prior_Content_Unchanged (This, This'Old);
 
    procedure Get_Boolean (This : in out ByteBuffer'Class;  Value : out Boolean) with
-     Pre  => Remaining (This) >= 1 and then
-             Position (This) <= High_Water_Mark (This) - 1,
-     Post => Position (This) = Position (This)'Old + 1             and then
-             High_Water_Mark (This) = High_Water_Mark (This)'Old   and then
-             Remaining (This) + 1 = Remaining (This)'Old           and then
-             (Raw_Bytes (This) (Position (This)'Old) /= 0) = Value and then
+     Pre  => Remaining (This) >= Boolean_Size and then
+             Position (This) <= High_Water_Mark (This) - Boolean_Size,
+     Post => Position (This) = Position (This)'Old + Boolean_Size   and then
+             High_Water_Mark (This) = High_Water_Mark (This)'Old    and then
+             Remaining (This) + Boolean_Size = Remaining (This)'Old and then
+             (Raw_Bytes (This) (Position (This)'Old) /= 0) = Value  and then
              Prior_Content_Unchanged (This, This'Old);
 
    procedure Get_Int16 (This : in out ByteBuffer'Class;  Value : out Int16) with
-     Pre  => Remaining (This) >= 2 and then
-             Position (This) <= High_Water_Mark (This) - 2,
-     Post => Position (This) = Position (This)'Old + 2           and then
-             High_Water_Mark (This) = High_Water_Mark (This)'Old and then
-             Remaining (This) + 2 = Remaining (This)'Old         and then
+     Pre  => Remaining (This) >= Int16_Size and then
+             Position (This) <= High_Water_Mark (This) - Int16_Size,
+     Post => Position (This) = Position (This)'Old + Int16_Size   and then
+             High_Water_Mark (This) = High_Water_Mark (This)'Old  and then
+             Remaining (This) + Int16_Size = Remaining (This)'Old and then
              Raw_Bytes (This) (Position (This)'Old .. Position (This) - 1) = As_Two_Bytes (Value) and then
              Prior_Content_Unchanged (This, This'Old);
 
    procedure Get_UInt16 (This : in out ByteBuffer'Class;  Value : out UInt16) with
-     Pre  => Remaining (This) >= 2 and then
-             Position (This) <= High_Water_Mark (This) - 2,
-     Post => Position (This) = Position (This)'Old + 2           and then
-             High_Water_Mark (This) = High_Water_Mark (This)'Old and then
-             Remaining (This) + 2 = Remaining (This)'Old         and then
+     Pre  => Remaining (This) >= UInt16_Size and then
+             Position (This) <= High_Water_Mark (This) - UInt16_Size,
+     Post => Position (This) = Position (This)'Old + UInt16_Size   and then
+             High_Water_Mark (This) = High_Water_Mark (This)'Old   and then
+             Remaining (This) + UInt16_Size = Remaining (This)'Old and then
              Raw_Bytes (This) (Position (This)'Old .. Position (This) - 1) = As_Two_Bytes (Value) and then
              Prior_Content_Unchanged (This, This'Old);
 
    procedure Get_Int32 (This : in out ByteBuffer'Class;  Value : out Int32) with
-     Pre  => Remaining (This) >= 4 and then
-             Position (This) <= High_Water_Mark (This) - 4,
-     Post => Position (This) = Position (This)'Old + 4           and then
-             High_Water_Mark (This) = High_Water_Mark (This)'Old and then
-             Remaining (This) + 4 = Remaining (This)'Old         and then
+     Pre  => Remaining (This) >= Int32_Size and then
+             Position (This) <= High_Water_Mark (This) - Int32_Size,
+     Post => Position (This) = Position (This)'Old + Int32_Size   and then
+             High_Water_Mark (This) = High_Water_Mark (This)'Old  and then
+             Remaining (This) + Int32_Size = Remaining (This)'Old and then
              Raw_Bytes (This) (Position (This)'Old .. Position (This) - 1) = As_Four_Bytes (Value) and then
              Prior_Content_Unchanged (This, This'Old);
 
@@ -102,64 +123,60 @@ is
       Value : out UInt32;
       First : Index)
    with
-     Pre  => First <= This.Capacity - 3 and then
-             First + 3 <= High_Water_Mark (This) - 1,
+     Pre  => First <= This.Capacity - UInt32_Size - 1 and then
+             First + UInt32_Size - 1 <= High_Water_Mark (This) - 1,
      Post => Position (This) = Position (This)'Old               and then
              High_Water_Mark (This) = High_Water_Mark (This)'Old and then
              Remaining (This) = Remaining (This)'Old             and then
              Raw_Bytes (This) = Raw_Bytes (This)'Old             and then
-             Raw_Bytes (This) (First .. First + 3) = As_Four_Bytes (Value);
+             Raw_Bytes (This) (First .. First + UInt32_Size - 1) = As_Four_Bytes (Value);
    --  Gets the four bytes comprising a UInt32 value from This buffer, starting
    --  at absolute index First (rather than from This.Position)
 
    procedure Get_UInt32 (This : in out ByteBuffer'Class;  Value : out UInt32) with
-     Pre  => Remaining (This) >= 4 and then
-             Position (This) <= High_Water_Mark (This) - 4,
-     Post => Position (This) = Position (This)'Old + 4           and then
-             High_Water_Mark (This) = High_Water_Mark (This)'Old and then
-             Remaining (This) + 4 = Remaining (This)'Old         and then
+     Pre  => Remaining (This) >= UInt32_Size and then
+             Position (This) <= High_Water_Mark (This) - UInt32_Size,
+     Post => Position (This) = Position (This)'Old + UInt32_Size   and then
+             High_Water_Mark (This) = High_Water_Mark (This)'Old    and then
+             Remaining (This) + UInt32_Size = Remaining (This)'Old and then
              Raw_Bytes (This) (Position (This)'Old .. Position (This) - 1) = As_Four_Bytes (Value) and then
              Prior_Content_Unchanged (This, This'Old);
 
    procedure Get_Int64  (This : in out ByteBuffer'Class;  Value : out Int64) with
-     Pre  => Remaining (This) >= 8 and then
-             Position (This) <= High_Water_Mark (This) - 8,
-     Post => Position (This) = Position (This)'Old + 8           and then
-             High_Water_Mark (This) = High_Water_Mark (This)'Old and then
-             Remaining (This) + 8 = Remaining (This)'Old         and then
+     Pre  => Remaining (This) >= Int64_Size and then
+             Position (This) <= High_Water_Mark (This) - Int64_Size,
+     Post => Position (This) = Position (This)'Old + Int64_Size   and then
+             High_Water_Mark (This) = High_Water_Mark (This)'Old   and then
+             Remaining (This) + Int64_Size = Remaining (This)'Old and then
              Raw_Bytes (This) (Position (This)'Old .. Position (This) - 1) = As_Eight_Bytes (Value) and then
              Prior_Content_Unchanged (This, This'Old);
 
    procedure Get_UInt64 (This : in out ByteBuffer'Class;  Value : out UInt64) with
-     Pre  => Remaining (This) >= 8 and then
-             Position (This) <= High_Water_Mark (This) - 8,
-     Post => Position (This) = Position (This)'Old + 8           and then
-             High_Water_Mark (This) = High_Water_Mark (This)'Old and then
-             Remaining (This) + 8 = Remaining (This)'Old         and then
+     Pre  => Remaining (This) >= UInt64_Size and then
+             Position (This) <= High_Water_Mark (This) - UInt64_Size,
+     Post => Position (This) = Position (This)'Old + UInt64_Size   and then
+             High_Water_Mark (This) = High_Water_Mark (This)'Old   and then
+             Remaining (This) + UInt64_Size = Remaining (This)'Old and then
              Raw_Bytes (This) (Position (This)'Old .. Position (This) - 1) = As_Eight_Bytes (Value) and then
              Prior_Content_Unchanged (This, This'Old);
 
    procedure Get_Real32 (This : in out ByteBuffer'Class;  Value : out Real32) with
-     Pre  => Remaining (This) >= 4 and then
-             Position (This) <= High_Water_Mark (This) - 4,
-     Post => Position (This) = Position (This)'Old + 4           and then
-             High_Water_Mark (This) = High_Water_Mark (This)'Old and then
-             Remaining (This) + 4 = Remaining (This)'Old         and then
+     Pre  => Remaining (This) >= Real32_Size and then
+             Position (This) <= High_Water_Mark (This) - Real32_Size,
+     Post => Position (This) = Position (This)'Old + Real32_Size   and then
+             High_Water_Mark (This) = High_Water_Mark (This)'Old    and then
+             Remaining (This) + Real32_Size = Remaining (This)'Old and then
              Raw_Bytes (This) (Position (This)'Old .. Position (This) - 1) = As_Four_Bytes (Value) and then
              Prior_Content_Unchanged (This, This'Old);
 
    procedure Get_Real64 (This : in out ByteBuffer'Class;  Value : out Real64) with
-     Pre  => Remaining (This) >= 8 and then
-             Position (This) <= High_Water_Mark (This) - 8,
-     Post => Position (This) = Position (This)'Old + 8           and then
-             High_Water_Mark (This) = High_Water_Mark (This)'Old and then
-             Remaining (This) + 8 = Remaining (This)'Old         and then
+     Pre  => Remaining (This) >= Real64_Size and then
+             Position (This) <= High_Water_Mark (This) - Real64_Size,
+     Post => Position (This) = Position (This)'Old + Real64_Size   and then
+             High_Water_Mark (This) = High_Water_Mark (This)'Old    and then
+             Remaining (This) + Real64_Size = Remaining (This)'Old and then
              Raw_Bytes (This) (Position (This)'Old .. Position (This) - 1) = As_Eight_Bytes (Value) and then
              Prior_Content_Unchanged (This, This'Old);
-
-   Max_String_Length : constant := 65_535;
-   --  Like the C++ version, we write strings' lengths as a UInt16 during
-   --  serialization.
 
    procedure Get_String
      (This          : in out ByteBuffer'Class;
@@ -173,41 +190,41 @@ is
        Value'First  in Positive               and then
        Value'Last   in Positive               and then
        Value'Length in 1 .. Max_String_Length and then
-       Remaining (This) >= 2                  and then
-       Position (This) <= High_Water_Mark (This) - 2,
+       Remaining (This) >= Stored_Length_Size and then
+       Position (This) <= High_Water_Mark (This) - Stored_Length_Size,
        --  The string content is preceded in the buffer by a two-byte length,
        --  even when the string length is zero (ie when the string is empty).
      Post =>
        High_Water_Mark (This) = High_Water_Mark (This)'Old and then
        Stored_Length <= Max_String_Length                  and then
        Raw_Bytes (This) (Position (This)'Old .. Position (This)'Old + 1) = As_Two_Bytes (UInt16 (Stored_Length)) and then
-       (if Index (Stored_Length) > Remaining (This)'Old - 2 then
+       (if Index (Stored_Length) > Remaining (This)'Old - Stored_Length_Size then
            --  This is a corrupted buffer: there are too few remaining bytes
            --  available in the buffer to be assigned to the String Value.
            Last = -1 and
-           Position (This) = Position (This)'Old + 2
+           Position (This) = Position (This)'Old + Stored_Length_Size
         elsif Stored_Length > Value'Length then
            --  Presumably client error; the buffer is not necessarily corrupted.
            Last = -1 and
-           Position (This) = Position (This)'Old + 2
+           Position (This) = Position (This)'Old + Stored_Length_Size
         elsif High_Water_Mark (This) + Index (Stored_length) > This.Capacity then
            Last = -1 and
-           Position (This) = Position (This)'Old + 2
-        elsif Position (This)'Old + 2 + Index (Stored_Length) > High_Water_Mark (This)'Old then
+           Position (This) = Position (This)'Old + Stored_Length_Size
+        elsif Position (This)'Old + Stored_Length_Size + Index (Stored_Length) > High_Water_Mark (This)'Old then
            Last = -1 and
-           Position (This) = Position (This)'Old + 2
+           Position (This) = Position (This)'Old + Stored_Length_Size
         elsif Stored_Length = 0 then
            --  This is a normal case, specifically for an empty string.
            Last = Value'First - 1 and then
-           Position (This) = Position (This)'Old + 2
+           Position (This) = Position (This)'Old + Stored_Length_Size
         else
            --  This is a normal case for a non-empty string in the buffer. If
            --  the stored length is <= Value'Length we only read Stored_Length
            --  number of chars from the buffer, potentially leaving some of
            --  Value unassigned (hence the need for Last).
-           Last = Value'First + (Positive (Stored_Length) - 1)               and then
-           Position (This) = Position (This)'Old + 2 + Index (Stored_Length) and then
-           Equal (Raw_Bytes (This) (Position (This)'Old + 2 .. Position (This) - 1),
+           Last = Value'First + (Positive (Stored_Length) - 1)                                and then
+           Position (This) = Position (This)'Old + Stored_Length_Size + Index (Stored_Length) and then
+           Equal (Raw_Bytes (This) (Position (This)'Old + Stored_Length_Size .. Position (This) - 1),
                   Value (Value'First .. Last)));
 
    procedure Get_Unbounded_String
@@ -215,134 +232,134 @@ is
       Value         : out Unbounded_String;
       Stored_Length : out UInt32)
    with
-     Pre  => Remaining (This) >= 2  and then
-             Position (This) <= High_Water_Mark (This) - 2,
+     Pre  => Remaining (This) >= Stored_Length_Size  and then
+             Position (This) <= High_Water_Mark (This) - Stored_Length_Size,
              --  The string content is preceded in the buffer by a two-byte length,
              --  even when the string length is zero (ie when the string is empty).
      Post => High_Water_Mark (This) = High_Water_Mark (This)'Old and then
-             Stored_Length <= UInt32 (UInt16'Last)               and then
+             Stored_Length <= Max_String_Length and then
              Raw_Bytes (This) (Position (This)'Old .. Position (This)'Old + 1) = As_Two_Bytes (UInt16 (Stored_Length)) and then
-             (if Index (Stored_Length) > Remaining (This)'Old - 2 or else
-                 Position (This)'Old + 2 + Index (Stored_length) > High_Water_Mark (This)
+             (if Index (Stored_Length) > Remaining (This)'Old - Stored_Length_Size or else
+                 Position (This)'Old + Stored_Length_Size + Index (Stored_length) > High_Water_Mark (This)
               then
                  To_String (Value) = "Corrupted buffer" and then
-                 Position (This) = Position (This)'Old + 2
+                 Position (This) = Position (This)'Old + Stored_Length_Size
               elsif Stored_Length = 0 then
-                 Position (This) = Position (This)'Old + 2
+                 Position (This) = Position (This)'Old + Stored_Length_Size
               else
-                 Position (This) = Position (This)'Old + 2 + Index (Stored_Length) and then
-                 Equal (Raw_Bytes (This) (Position (This)'Old + 2 .. Position (This) - 1),
+                 Position (This) = Position (This)'Old + Stored_Length_Size + Index (Stored_Length) and then
+                 Equal (Raw_Bytes (This) (Position (This)'Old + Stored_Length_Size .. Position (This) - 1),
                         To_String (Value)));
 
    procedure Put_Byte (This : in out ByteBuffer'Class;  Value : Byte) with
-     Pre  => Remaining (This) >= 1 and then
-             High_Water_Mark (This) <= This.Capacity - 1,
-     Post => Position (This) = Position (This)'Old + 1               and then
-             High_Water_Mark (This) = High_Water_Mark (This)'Old + 1 and then
-             Remaining (This) + 1 = Remaining (This)'Old             and then
-             Raw_Bytes (This) (Position (This)'Old) = Value          and then
+     Pre  => Remaining (This) >= Byte_Size and then
+             High_Water_Mark (This) <= This.Capacity - Byte_Size,
+     Post => Position (This) = Position (This)'Old + Byte_Size               and then
+             High_Water_Mark (This) = High_Water_Mark (This)'Old + Byte_Size and then
+             Remaining (This) + Byte_Size = Remaining (This)'Old             and then
+             Raw_Bytes (This) (Position (This)'Old) = Value                  and then
              Prior_Content_Unchanged (This, This'Old);
 
    procedure Put_Boolean (This : in out ByteBuffer'Class;  Value : Boolean) with
-     Pre  => Remaining (This) >= 1 and then
-             High_Water_Mark (This) <= This.Capacity - 1,
-     Post => Position (This) = Position (This)'Old + 1                    and then
-             High_Water_Mark (This) = High_Water_Mark (This)'Old + 1      and then
-             Remaining (This) + 1 = Remaining (This)'Old                  and then
-             Raw_Bytes (This) (Position (This)'Old) = Boolean'Pos (Value) and then
+     Pre  => Remaining (This) >= Boolean_Size and then
+             High_Water_Mark (This) <= This.Capacity - Boolean_Size,
+     Post => Position (This) = Position (This)'Old + Boolean_Size               and then
+             High_Water_Mark (This) = High_Water_Mark (This)'Old + Boolean_Size and then
+             Remaining (This) + Boolean_Size = Remaining (This)'Old             and then
+             Raw_Bytes (This) (Position (This)'Old) = Boolean'Pos (Value)       and then
              Prior_Content_Unchanged (This, This'Old);
 
    procedure Put_Int16 (This : in out ByteBuffer'Class;  Value : Int16) with
-     Pre  => Remaining (This) >= 2 and then
-             High_Water_Mark (This) <= This.Capacity - 2,
-     Post => Position (This) = Position (This)'Old + 2               and then
-             High_Water_Mark (This) = High_Water_Mark (This)'Old + 2 and then
-             Remaining (This) + 2 = Remaining (This)'Old             and then
+     Pre  => Remaining (This) >= Int16_Size and then
+             High_Water_Mark (This) <= This.Capacity - Int16_Size,
+     Post => Position (This) = Position (This)'Old + Int16_Size               and then
+             High_Water_Mark (This) = High_Water_Mark (This)'Old + Int16_Size and then
+             Remaining (This) + Int16_Size = Remaining (This)'Old             and then
              Raw_Bytes (This) (Position (This)'Old .. Position (This) - 1) = As_Two_Bytes (Value) and then
              Prior_Content_Unchanged (This, This'Old);
 
    procedure Put_UInt16 (This : in out ByteBuffer'Class;  Value : UInt16) with
-     Pre  => Remaining (This) >= 2 and then
-             High_Water_Mark (This) <= This.Capacity - 2,
-     Post => Position (This) = Position (This)'Old + 2               and then
-             High_Water_Mark (This) = High_Water_Mark (This)'Old + 2 and then
-             Remaining (This) + 2 = Remaining (This)'Old             and then
+     Pre  => Remaining (This) >= UInt16_Size and then
+             High_Water_Mark (This) <= This.Capacity - UInt16_Size,
+     Post => Position (This) = Position (This)'Old + UInt16_Size               and then
+             High_Water_Mark (This) = High_Water_Mark (This)'Old + UInt16_Size and then
+             Remaining (This) + UInt16_Size = Remaining (This)'Old             and then
              Raw_Bytes (This) (Position (This)'Old .. Position (This) - 1) = As_Two_Bytes (Value) and then
              Prior_Content_Unchanged (This, This'Old);
 
    procedure Put_Int32 (This : in out ByteBuffer'Class;  Value : Int32) with
-     Pre  => Remaining (This) >= 4 and then
-             High_Water_Mark (This) <= This.Capacity - 4,
-     Post => Position (This) = Position (This)'Old + 4               and then
-             High_Water_Mark (This) = High_Water_Mark (This)'Old + 4 and then
-             Remaining (This) + 4 = Remaining (This)'Old             and then
+     Pre  => Remaining (This) >= Int32_Size and then
+             High_Water_Mark (This) <= This.Capacity - Int32_Size,
+     Post => Position (This) = Position (This)'Old + Int32_Size               and then
+             High_Water_Mark (This) = High_Water_Mark (This)'Old + Int32_Size and then
+             Remaining (This) + Int32_Size = Remaining (This)'Old             and then
              Raw_Bytes (This) (Position (This)'Old .. Position (This) - 1) = As_Four_Bytes (Value) and then
              Prior_Content_Unchanged (This, This'Old);
 
    procedure Put_UInt32 (This : in out ByteBuffer'Class;  Value : UInt32) with
-     Pre  => Remaining (This) >= 4 and then
-             High_Water_Mark (This) <= This.Capacity - 4,
-     Post => Position (This) = Position (This)'Old + 4               and then
-             High_Water_Mark (This) = High_Water_Mark (This)'Old + 4 and then
-             Remaining (This) + 4 = Remaining (This)'Old             and then
+     Pre  => Remaining (This) >= UInt32_Size and then
+             High_Water_Mark (This) <= This.Capacity - UInt32_Size,
+     Post => Position (This) = Position (This)'Old + UInt32_Size               and then
+             High_Water_Mark (This) = High_Water_Mark (This)'Old + UInt32_Size and then
+             Remaining (This) + UInt32_Size = Remaining (This)'Old             and then
              Raw_Bytes (This) (Position (This)'Old .. Position (This) - 1) = As_Four_Bytes (Value) and then
              Prior_Content_Unchanged (This, This'Old);
 
    procedure Put_Int64 (This : in out ByteBuffer'Class;  Value : Int64) with
-     Pre  => Remaining (This) >= 8 and then
-             High_Water_Mark (This) <= This.Capacity - 8,
-     Post => Position (This) = Position (This)'Old + 8               and then
-             High_Water_Mark (This) = High_Water_Mark (This)'Old + 8 and then
-             Remaining (This) + 8 = Remaining (This)'Old             and then
+     Pre  => Remaining (This) >= Int64_Size and then
+             High_Water_Mark (This) <= This.Capacity - Int64_Size,
+     Post => Position (This) = Position (This)'Old + Int64_Size               and then
+             High_Water_Mark (This) = High_Water_Mark (This)'Old + Int64_Size and then
+             Remaining (This) + Int64_Size = Remaining (This)'Old             and then
              Raw_Bytes (This) (Position (This)'Old .. Position (This) - 1) = As_Eight_Bytes (Value) and then
              Prior_Content_Unchanged (This, This'Old);
 
    procedure Put_UInt64 (This : in out ByteBuffer'Class;  Value : UInt64) with
-     Pre  => Remaining (This) >= 8 and then
-             High_Water_Mark (This) <= This.Capacity - 8,
-     Post => Position (This) = Position (This)'Old + 8               and then
-             High_Water_Mark (This) = High_Water_Mark (This)'Old + 8 and then
-             Remaining (This) + 8 = Remaining (This)'Old             and then
+     Pre  => Remaining (This) >= UInt64_Size and then
+             High_Water_Mark (This) <= This.Capacity - UInt64_Size,
+     Post => Position (This) = Position (This)'Old + UInt64_Size               and then
+             High_Water_Mark (This) = High_Water_Mark (This)'Old + UInt64_Size and then
+             Remaining (This) + UInt64_Size = Remaining (This)'Old             and then
              Raw_Bytes (This) (Position (This)'Old .. Position (This) - 1) = As_Eight_Bytes (Value) and then
              Prior_Content_Unchanged (This, This'Old);
 
    procedure Put_Real32 (This : in out ByteBuffer'Class;  Value : Real32) with
-     Pre  => Remaining (This) >= 4 and then
-             High_Water_Mark (This) <= This.Capacity - 4,
-     Post => Position (This) = Position (This)'Old + 4               and then
-             High_Water_Mark (This) = High_Water_Mark (This)'Old + 4 and then
-             Remaining (This) + 4 = Remaining (This)'Old             and then
+     Pre  => Remaining (This) >= Real32_Size and then
+             High_Water_Mark (This) <= This.Capacity - Real32_Size,
+     Post => Position (This) = Position (This)'Old + Real32_Size               and then
+             High_Water_Mark (This) = High_Water_Mark (This)'Old + Real32_Size and then
+             Remaining (This) + Real32_Size = Remaining (This)'Old             and then
              Raw_Bytes (This) (Position (This)'Old .. Position (This) - 1) = As_Four_Bytes (Value) and then
              Prior_Content_Unchanged (This, This'Old);
 
    procedure Put_Real64 (This : in out ByteBuffer'Class;  Value : Real64) with
-     Pre  => Remaining (This) >= 8 and then
-             High_Water_Mark (This) <= This.Capacity - 8,
-     Post => Position (This) = Position (This)'Old + 8               and then
-             High_Water_Mark (This) = High_Water_Mark (This)'Old + 8 and then
-             Remaining (This) + 8 = Remaining (This)'Old             and then
+     Pre  => Remaining (This) >= Real64_Size and then
+             High_Water_Mark (This) <= This.Capacity - Real64_Size,
+     Post => Position (This) = Position (This)'Old + Real64_Size               and then
+             High_Water_Mark (This) = High_Water_Mark (This)'Old + Real64_Size and then
+             Remaining (This) + Real64_Size = Remaining (This)'Old             and then
              Raw_Bytes (This) (Position (This)'Old .. Position (This) - 1) = As_Eight_Bytes (Value) and then
              Prior_Content_Unchanged (This, This'Old);
 
    procedure Put_String (This : in out ByteBuffer'Class;  Value : String) with
      Pre  => Value'First = 1                      and then
              Value'Length <= Max_String_Length    and then
-             Remaining (This) >= Value'Length + 2 and then  -- 2 bytes for the length
-             High_Water_Mark (This) <= This.Capacity - Value'Length - 2,
-     Post => Position (This) = Position (This)'Old + Value'Length + 2               and then
-             High_Water_Mark (This) = High_Water_Mark (This)'Old + Value'Length + 2 and then
-             Remaining (This) = Remaining (This)'Old - Value'Length - 2             and then
-             New_Content_Equal (This, This.Position'Old + 2, Value)                 and then
+             Remaining (This) >= Value'Length + Stored_Length_Size and then
+             High_Water_Mark (This) <= This.Capacity - Value'Length - Stored_Length_Size,
+     Post => Position (This) = Position (This)'Old + Value'Length + Stored_Length_Size               and then
+             High_Water_Mark (This) = High_Water_Mark (This)'Old + Value'Length + Stored_Length_Size and then
+             Remaining (This) = Remaining (This)'Old - Value'Length - Stored_Length_Size             and then
+             New_Content_Equal (This, This.Position'Old + Stored_Length_Size, Value)                 and then
              Prior_Content_Unchanged (This, Old_Value => This'Old);
 
    procedure Put_Unbounded_String (This : in out ByteBuffer'Class; Value : Unbounded_String) with
      Pre  => Length (Value) <= Max_String_Length and then
-             Remaining (This) >= Index (Length (Value)) + 2 and then  -- 2 bytes for the length
-             High_Water_Mark (This) <= This.Capacity - Index (Length (Value)) - 2,
-     Post => Position (This) = Position (This)'Old + Index (Length (Value)) + 2               and then
-             High_Water_Mark (This) = High_Water_Mark (This)'Old + Index (Length (Value)) + 2 and then
-             Remaining (This) = Remaining (This)'Old - Index (Length (Value)) - 2             and then
-             New_Content_Equal (This, This.Position'Old + 2, To_String (Value))               and then
+             Remaining (This) >= Index (Length (Value)) + Stored_Length_Size and then
+             High_Water_Mark (This) <= This.Capacity - Index (Length (Value)) - Stored_Length_Size,
+     Post => Position (This) = Position (This)'Old + Index (Length (Value)) + Stored_Length_Size               and then
+             High_Water_Mark (This) = High_Water_Mark (This)'Old + Index (Length (Value)) + Stored_Length_Size and then
+             Remaining (This) = Remaining (This)'Old - Index (Length (Value)) - Stored_Length_Size             and then
+             New_Content_Equal (This, This.Position'Old + Stored_Length_Size, To_String (Value))               and then
              Prior_Content_Unchanged (This, Old_Value => This'Old);
 
    --  The following two Put_Raw_Bytes routines populate the ByteBuffer from

--- a/src/templates/ada/avtas/lmcp/avtas-lmcp-factory.adb
+++ b/src/templates/ada/avtas/lmcp/avtas-lmcp-factory.adb
@@ -20,7 +20,7 @@ package body AVTAS.LMCP.Factory is
       -- add root object
       PutObject (RootObject, Buffer);
       -- add checksum if enabled
-      Put_UInt32 (Buffer, (if EnableChecksum then CalculatedChecksum (Buffer, Buffer.Capacity) else 0));
+      Put_UInt32 (Buffer, (if EnableChecksum then CalculatedChecksum (Buffer, High_Water_Mark (Buffer) - 1) else 0));
       return Buffer;
    end PackMessage;
 
@@ -117,7 +117,7 @@ package body AVTAS.LMCP.Factory is
    ------------------------
 
    function CalculatedChecksum (Buffer : in ByteBuffer; Size : Index) return UInt32 is
-     (Checksum (Buffer, Last => Size - 1));
+     (Checksum (Buffer, Last => Size));
 
    -------------------
    -- GetObjectSize --

--- a/src/templates/ada/avtas/lmcp/avtas-lmcp-factory.adb
+++ b/src/templates/ada/avtas/lmcp/avtas-lmcp-factory.adb
@@ -15,12 +15,12 @@ package body AVTAS.LMCP.Factory is
       Buffer  : ByteBuffer (HEADER_SIZE + Index (MsgSize) + CHECKSUM_SIZE);
    begin
       -- add header values
-      Buffer.Put_Int32 (LMCP_CONTROL_STR);
-      Buffer.Put_UInt32 (MsgSize);
+      Put_Int32 (Buffer, LMCP_CONTROL_STR);
+      Put_UInt32 (Buffer, MsgSize);
       -- add root object
       PutObject (RootObject, Buffer);
       -- add checksum if enabled
-      Buffer.Put_UInt32 (if EnableChecksum then CalculatedChecksum (Buffer, Buffer.Capacity) else 0);
+      Put_UInt32 (Buffer, (if EnableChecksum then CalculatedChecksum (Buffer, Buffer.Capacity) else 0));
       return Buffer;
    end PackMessage;
 
@@ -32,12 +32,12 @@ package body AVTAS.LMCP.Factory is
    begin
       -- If object is null, pack a 0; otherwise, add root object
       if Object = null then
-         Buffer.Put_Boolean (False);
+         Put_Boolean (Buffer, False);
       else
-         Buffer.Put_Boolean (True);
-         Buffer.Put_Int64 (Object.GetSeriesNameAsLong);
-         Buffer.Put_UInt32 (Object.GetLmcpType);
-         Buffer.Put_UInt16 (Object.GetSeriesVersion);
+         Put_Boolean (Buffer, True);
+         Put_Int64 (Buffer, Object.GetSeriesNameAsLong);
+         Put_UInt32 (Buffer, Object.GetLmcpType);
+         Put_UInt16 (Buffer, Object.GetSeriesVersion);
          Object.Pack (Buffer);
       end if;
    end PutObject;
@@ -55,46 +55,46 @@ package body AVTAS.LMCP.Factory is
       Version   : Uint16;
    begin
       Output := null; -- default
-      
-      if buffer.Capacity < HEADER_SIZE + CHECKSUM_SIZE then
-         Put_Line ("AVTAS.LMCP.Factory.GetObject error: Buffer capacity too small for header and checksum (" & 
-                   Integer'Image(HEADER_SIZE + CHECKSUM_SIZE) & ").");         
+
+      if Buffer.Capacity < HEADER_SIZE + CHECKSUM_SIZE then
+         Put_Line ("AVTAS.LMCP.Factory.GetObject error: Buffer capacity too small for header and checksum (" &
+                   Integer'Image(HEADER_SIZE + CHECKSUM_SIZE) & ").");
          raise Program_Error;  -- for the moment
          --  return;
       end if;
-      
-      Buffer.Get_Int32 (CtrlStr);
+
+      Get_Int32 (Buffer, CtrlStr);
       if CtrlStr /= LMCP_CONTROL_STR then
          Put_Line ("AVTAS.LMCP.Factory.GetObject error: Not a proper LMCP message.");
          Put_Line ("   Expected: " & LMCP_CONTROL_STR'Image & "   Received: " & CtrlStr'Image);
          raise Program_Error;  -- for the moment
          --  return;
       end if;
-      
-      Buffer.Get_UInt32 (MsgSize);
+
+      Get_UInt32 (Buffer, MsgSize);
       if Buffer.Capacity < Index (MsgSize) then
          Put_Line ("AVTAS.LMCP.Factory.GetObject error: Buffer size too small for packed object.");
          Put_Line ("   MsgSize: " & MsgSize'Image & "    Capacity: " & Buffer.Capacity'Image);
          raise Program_Error;  -- for the moment
          --  return;
       end if;
-      
+
       if not Validated (Buffer) then
          Put_Line ("AVTAS.LMCP.Factory.GetObject error: Checksum invalid.");
          raise Program_Error;  -- for the moment
          --  return;
       end if;
-      
-      Buffer.Get_Boolean (MsgExists);
+
+      Get_Boolean (Buffer, MsgExists);
       if not MsgExists then
          Put_Line ("AVTAS.LMCP.Factory.GetObject error: Message indicated it was packed as null");
          raise Program_Error;  -- for the moment
          --  return;
       end if;
 
-      Buffer.Get_Int64 (SeriesId);
-      Buffer.Get_UInt32 (MsgType);
-      Buffer.Get_UInt16 (Version);
+      Get_Int64 (Buffer, SeriesId);
+      Get_UInt32 (Buffer, MsgType);
+      Get_UInt16 (Buffer, Version);
       Output := CreateObject (SeriesId, MsgType, Version);
       if Output /= null then
          Output.Unpack (Buffer);
@@ -117,7 +117,7 @@ package body AVTAS.LMCP.Factory is
    ------------------------
 
    function CalculatedChecksum (Buffer : in ByteBuffer; Size : Index) return UInt32 is
-     (Buffer.Checksum (Last => Size - 1));
+     (Checksum (Buffer, Last => Size - 1));
 
    -------------------
    -- GetObjectSize --
@@ -125,10 +125,10 @@ package body AVTAS.LMCP.Factory is
 
    function GetObjectSize (Buffer : in ByteBuffer) return UInt32 is
       Result : UInt32;
-      Second_HalfWord_Start : constant Index := 4;  -- the buffer array is zero-based
+      Second_HalfWord_Start : constant Index := UInt32_Size;  -- the buffer array is zero-based
    begin
       --  get the second UInt32 value in the buffer
-      Buffer.Get_UInt32 (Result, First => Second_HalfWord_Start);  
+      Get_UInt32 (Buffer, Result, First => Second_HalfWord_Start);
       return Result;
    end getObjectSize;
 
@@ -139,12 +139,13 @@ package body AVTAS.LMCP.Factory is
    function Validated (Buffer : in ByteBuffer) return Boolean is
       Stored_Checksum : UInt32;
    begin
-      if Buffer.High_Water_Mark < HEADER_SIZE + CHECKSUM_SIZE then
+      if High_Water_Mark (Buffer) < HEADER_SIZE + CHECKSUM_SIZE then
          Put_Line ("AVTAS.LMCP.Factory.Validated: Buffer size < HEADER_SIZE + CHECKSUM_SIZE.");
          return False;
       end if;
-      Buffer.Get_UInt32 (Stored_Checksum, First => Buffer.High_Water_Mark - Checksum_Size);
-      return Stored_Checksum = 0 or else Stored_Checksum = CalculatedChecksum (Buffer, Buffer.High_Water_Mark - Checksum_Size);
+      Get_UInt32 (Buffer, Stored_Checksum, First => High_Water_Mark (Buffer) - Checksum_Size);
+      return Stored_Checksum = 0 or else
+             Stored_Checksum = CalculatedChecksum (Buffer, High_Water_Mark (Buffer) - Checksum_Size);
    end Validated;
 
 end AVTAS.LMCP.Factory;

--- a/src/templates/ada/avtas/lmcp/conversion_equality_lemmas.ads
+++ b/src/templates/ada/avtas/lmcp/conversion_equality_lemmas.ads
@@ -14,6 +14,7 @@ is
       These_Bytes  : Bytes)
    with
      Ghost,
+     Always_Terminates,
      Post => These_Bytes = To_Bytes (This_Numeric)   and  -- this conversion
              To_Bytes (This_Numeric) = These_Bytes   and  -- and the other order too
              This_Numeric = To_Numeric (These_Bytes) and  -- and this conversion

--- a/src/templates/ada/avtas/lmcp/prove_bytebuffers.adb
+++ b/src/templates/ada/avtas/lmcp/prove_bytebuffers.adb
@@ -18,13 +18,13 @@ begin
 
    declare
       C : constant := 100; -- arbitrary
-      B : ByteBuffer (Capacity => C);
+      Buffer : ByteBuffer (Capacity => C);
       V : UInt16;
    begin
       Put_Line ("Get (first) value after rewind");
-      B.Put_Uint16 (42);
-      B.Rewind;
-      B.Get_UInt16 (V);
+      Put_Uint16 (Buffer, 42);
+      Rewind (Buffer);
+      Get_UInt16 (Buffer, V);
       pragma Assert (V = 42);
    end;
 
@@ -46,11 +46,11 @@ begin
       Buffer : ByteBuffer (Capacity => 100);
    begin
       Put_Line ("Get_UInt32 from absolute index > position and <= high water mark");
-      Buffer.Put_String (String_Input);
-      Buffer.Put_UInt32 (UInt32_Input);
-      Buffer.Put_Byte (Byte_Input);
+      Put_String (Buffer, String_Input);
+      Put_UInt32 (Buffer, UInt32_Input);
+      Put_Byte (Buffer, Byte_Input);
 
-      Buffer.Rewind;
+      Rewind (Buffer);
 
       Assert (Position (Buffer) = 0);
       Assert (High_Water_Mark (Buffer) = Expected_High_Water_Mark);
@@ -61,7 +61,7 @@ begin
       declare
          Output : UInt32;
       begin
-         Buffer.Get_UInt32 (Output, First => Index_After_String);
+         Get_UInt32 (Buffer, Output, First => Index_After_String);
          pragma Assert (Output = UInt32_Input);
       end;
    end;
@@ -70,28 +70,28 @@ begin
 
    declare
       C : constant := 100; -- arbitrary
-      B : ByteBuffer (Capacity => C);
+      Buffer : ByteBuffer (Capacity => C);
       L : constant := C - 2;  -- leave room for length inserted into buffer too
       S : constant String (1 .. L) := (others => 'x');
    begin
       Put_Line ("Inserting string with length < capacity");
-      B.Put_String (S);
+      Put_String (Buffer, S);
    end;
 
    declare
       C : constant := UInt16'Last;
-      B : ByteBuffer (Capacity => C + 2);
+      Buffer : ByteBuffer (Capacity => C + 2);
       S : constant String (1 .. Integer (UInt16'Last)) := (others => 'x');
    begin
       Put_Line ("Inserting string with length = UInt16'Last, with sufficient capacity");
-      B.Put_String (S);
+      Put_String (Buffer, S);
    end;
 
 --  getting Strings ----------------------------------------------------------
 
    declare
       C : constant := 100; -- arbitrary
-      B : ByteBuffer (Capacity => C);
+      Buffer : ByteBuffer (Capacity => C);
       Corrupted_String_Length : constant := C + 1; -- anything > C will do
       S : String (1 .. Corrupted_String_Length) := (others => ' ');
       Last : Integer;
@@ -100,54 +100,54 @@ begin
       Put_Line ("Getting string with stored length > remaining bytes in message");
       --  Write a value that Get_String is going to read as the length of the
       --  string in the message. The value must be > buffer capacity.
-      B.Put_UInt16 (Corrupted_String_Length);
+      Put_UInt16 (Buffer, Corrupted_String_Length);
       --  Prepare to start getting values as if a message is in the buffer,
       --  starting with a string. The actual characters are immaterial so we
-      --  don't bother to insert them into the buffer.
+      --  don't bother to insert them into the
       --
       --  Note that this wouldn't happen without some sort of buffer
       --  corruption because Put_String would have failed when attempting to
       --  write that any chars into the buffer (since we know the buffer isn't
       --  big enough in this test, on purpose).
 
-      B.Rewind;
-      B.Get_String (S, Last, Unused);
-      pragma Assert (B.Position = 2);
+      Rewind (Buffer);
+      Get_String (Buffer, S, Last, Unused);
+      pragma Assert (Position (Buffer) = 2);
       pragma Assert (Last = -1);
    end;
 
    -- the case in which stored length > string arg length AND we just set Last to -1
    declare
       C : constant := 10; -- arbitrary
-      B : ByteBuffer (Capacity => C);
+      Buffer : ByteBuffer (Capacity => C);
       Written : constant String (1 .. 8) := "helloyou";
       Read : String (1 .. 5) := (others => ' ');
       Last : Integer;
       Stored_Length : UInt32;
    begin
       Put_Line ("Getting string with stored length > arg length");
-      B.Put_String (Written);
-      B.Rewind;
-      B.Get_String (Read, Last, Stored_Length);
+      Put_String (Buffer, Written);
+      Rewind (Buffer);
+      Get_String (Buffer, Read, Last, Stored_Length);
 
       pragma Assert (Last = -1);
-      pragma Assert (B.Position = 2);
+      pragma Assert (Position (Buffer) = 2);
    end;
 
    declare
       C : constant := 100; -- arbitrary
-      B : ByteBuffer (Capacity => C);
+      Buffer : ByteBuffer (Capacity => C);
       Written : constant String (1 .. 5) := "world";
       Read : String (1 .. 10) := (others => ' ');
       Last : Integer;
       Unused : UInt32;
    begin
       Put_Line ("Getting string with stored length < arg length");
-      B.Put_String (Written);
+      Put_String (Buffer, Written);
       --  prepare to start getting values as if a message is in the buffer,
       --  starting with a string
-      B.Rewind;
-      B.Get_String (Read, Last, Unused);
+      Rewind (Buffer);
+      Get_String (Buffer, Read, Last, Unused);
       pragma Assert (Last = Written'Length);
       pragma Assert (Read (1 .. Last) = Written);
    end;
@@ -157,38 +157,38 @@ begin
    declare
       C : constant := 100; -- arbitrary
       L : constant := C - 2;  -- leave room for length inserted into buffer too
-      B : ByteBuffer (Capacity => C);
+      Buffer : ByteBuffer (Capacity => C);
       S : constant ASU.Unbounded_String := ASU.To_Unbounded_String (Source => String'(1 .. L => 'x'));
    begin
       Put_Line ("Inserting unbounded string with length < capacity");
-      B.Put_Unbounded_String (S);
+      Put_Unbounded_String (Buffer, S);
    end;
 
    declare
       C : constant := 2;  -- the 2 bytes for the string's bounds
-      B : ByteBuffer (Capacity => C);
+      Buffer : ByteBuffer (Capacity => C);
       L : constant := 0;
       S : constant ASU.Unbounded_String := ASU.To_Unbounded_String (Source => String'(1 .. L => 'x'));
    begin
       Put_Line ("Inserting unbounded string with length = 0, with sufficient capacity");
-      B.Put_Unbounded_String (S);
+      Put_Unbounded_String (Buffer, S);
    end;
 
    declare
       C : constant := 100; -- arbitrary
       L : constant := C - 2;  -- leave room for length inserted into buffer too
-      B : ByteBuffer (Capacity => C);
+      Buffer : ByteBuffer (Capacity => C);
       S : constant ASU.Unbounded_String := ASU.To_Unbounded_String (Source => String'(1 .. L => 'x'));
    begin
       Put_Line ("Inserting unbounded string with length < capacity");
-      B.Put_Unbounded_String (S);
+      Put_Unbounded_String (Buffer, S);
    end;
 
 --  reading unbounded strings -------------------------------------------------
 
    declare
       C : constant := Max_String_Length;
-      B : ByteBuffer (Capacity => C + 2);
+      Buffer : ByteBuffer (Capacity => C + 2);
       L : constant := Integer (C);
       S : constant ASU.Unbounded_String := ASU.To_Unbounded_String (Source => String'(1 .. L => 'x'));
       O : ASU.Unbounded_String := ASU.To_Unbounded_String (Length => L);
@@ -196,9 +196,9 @@ begin
       use ASU;
    begin
       Put_Line ("Getting unbounded string with length = Max_String_Length, with sufficient capacity");
-      B.Put_Unbounded_String (S);
-      B.Rewind;
-      B.Get_Unbounded_String (O, Num_Stored);
+      Put_Unbounded_String (Buffer, S);
+      Rewind (Buffer);
+      Get_Unbounded_String (Buffer, O, Num_Stored);
       pragma Assert (Num_Stored = Max_String_Length);
       pragma Assert (O = S);
    end;
@@ -207,22 +207,22 @@ begin
 
    declare
       C : constant := 100; -- arbitrary
-      B : ByteBuffer (Capacity => C);
+      Buffer : ByteBuffer (Capacity => C);
       L : constant := C - 2;  -- leave room for length inserted into buffer too
       S : constant String (1 .. L) := (others => 'x');
    begin
       Put_Line ("Inserting raw bytes from String with length < capacity");
-      B.Put_Raw_Bytes (S);
+      Put_Raw_Bytes (Buffer, S);
    end;
 
    declare
       C : constant := 100; -- arbitrary
-      B : ByteBuffer (Capacity => C);
+      Buffer : ByteBuffer (Capacity => C);
       L : constant := C - 2;  -- leave room for length inserted into buffer too
       S : constant Byte_Array (1 .. L) := (others => Character'Pos ('x'));
    begin
       Put_Line ("Inserting raw bytes with length < capacity");
-      B.Put_Raw_Bytes (S);
+      Put_Raw_Bytes (Buffer, S);
    end;
 
    declare
@@ -241,7 +241,7 @@ begin
         (Object => Constrained_Byte_Array, Name => Byte_Array_Pointer);
    begin
       Put_Line ("Inserting raw bytes with length = Positive'Last");
-      BBP.Put_Raw_Bytes (BAP.all);
+      Put_Raw_Bytes (BBP.all, BAP.all);
       --  and free them to keep SPARK happy
       Free (BAP);
       Free (BBP);
@@ -262,22 +262,22 @@ begin
       Put_Line ("Multiple writes folowed by reads of those written values");
 
       --  NB: the order of the following must match the order of the calls to Get_* below
-      Buffer.Put_Byte (Byte_Input);
-      Buffer.Put_String (String_Input);
-      Buffer.Put_UInt32 (UInt32_Input);
-      Buffer.Put_Unbounded_String (ASU.To_Unbounded_String (String_Input));
-      Buffer.Put_Real32 (Real32_Input);
-      Buffer.Put_Boolean (Boolean_Input);
-      Buffer.Put_UInt64 (UInt64_Input);
+      Put_Byte (Buffer, Byte_Input);
+      Put_String (Buffer, String_Input);
+      Put_UInt32 (Buffer, UInt32_Input);
+      Put_Unbounded_String (Buffer, ASU.To_Unbounded_String (String_Input));
+      Put_Real32 (Buffer, Real32_Input);
+      Put_Boolean (Buffer, Boolean_Input);
+      Put_UInt64 (Buffer, UInt64_Input);
 
       --  now we read back what was written
 
-      Buffer.Rewind;
+      Rewind (Buffer);
 
       declare
          Output : Byte;
       begin
-         Buffer.Get_Byte (Output);
+         Get_Byte (Buffer, Output);
          pragma Assert (Output = Byte_Input);
       end;
 
@@ -286,7 +286,7 @@ begin
          Last   : Integer;  -- because result can be -1 to signal a problem
          Unused : UInt32;
       begin
-         Buffer.Get_String (Output, Last, Unused);
+         Get_String (Buffer, Output, Last, Unused);
          pragma Assert (Last = String_Input'Length);
          pragma Assert (Output (1 .. Last) = String_Input);
       end;
@@ -294,7 +294,7 @@ begin
       declare
          Output : UInt32;
       begin
-         Buffer.Get_UInt32 (Output);
+         Get_UInt32 (Buffer, Output);
          pragma Assert (Output = UInt32_Input);
       end;
 
@@ -302,7 +302,7 @@ begin
          Output : ASU.Unbounded_String;
          Num_Stored : UInt32;
       begin
-         Buffer.Get_Unbounded_String (Output, Num_Stored);
+         Get_Unbounded_String (Buffer, Output, Num_Stored);
          pragma Assert (Num_Stored = String_Input'Length);
          pragma Assert (ASU.To_String (Output) = String_Input);
       end;
@@ -310,21 +310,21 @@ begin
       declare
          Output : Real32;
       begin
-         Buffer.Get_Real32 (Output);
+         Get_Real32 (Buffer, Output);
          pragma Assert (Output = Real32_Input);
       end;
 
       declare
          Output : Boolean;
       begin
-         Buffer.Get_Boolean (Output);
+         Get_Boolean (Buffer, Output);
          pragma Assert (Output = Boolean_Input);
       end;
 
       declare
          Output : UInt64;
       begin
-         Buffer.Get_UInt64 (Output);
+         Get_UInt64 (Buffer, Output);
          pragma Assert (Output = UInt64_Input);
       end;
    end;

--- a/src/templates/ada/avtas/lmcp/prove_bytebuffers.adb
+++ b/src/templates/ada/avtas/lmcp/prove_bytebuffers.adb
@@ -1,0 +1,333 @@
+with AVTAS.LMCP.ByteBuffers; use AVTAS.LMCP.ByteBuffers;
+with Ada.Text_IO;            use Ada.Text_IO;
+with Ada.Assertions;         use Ada.Assertions;
+with Ada.Strings.Unbounded;
+with AVTAS.LMCP.Types;       use AVTAS.LMCP.Types;
+with Ada.Unchecked_Deallocation;
+
+procedure Prove_ByteBuffers with
+   SPARK_Mode
+is
+   package ASU renames Ada.Strings.Unbounded;
+begin
+
+   pragma Warnings (Off, "has no effect");
+   pragma Warnings (Off, "not used after the call");
+
+--  get from relative index after rewind -------------------------------------
+
+   declare
+      C : constant := 100; -- arbitrary
+      B : ByteBuffer (Capacity => C);
+      V : UInt16;
+   begin
+      Put_Line ("Get (first) value after rewind");
+      B.Put_Uint16 (42);
+      B.Rewind;
+      B.Get_UInt16 (V);
+      pragma Assert (V = 42);
+   end;
+
+--  get from absolute index --------------------------------------------------
+
+   declare
+      --                                  123456789ABC
+      String_Input  : constant String := "Hello World!";
+      Index_After_String : constant := 2 + String_Input'Length;
+      --  the 2-byte length of the string precedes the actual string content so
+      --  we add 2
+
+      UInt32_Input  : constant UInt32 := 42;
+      Byte_Input    : constant Byte := 42;
+
+      Expected_High_Water_Mark : constant := 2 + String_Input'Length + 4 + 1;
+      --  2-bytes for string length + length of string + 4 bytes for uint32 + 1 byte for boolean
+
+      Buffer : ByteBuffer (Capacity => 100);
+   begin
+      Put_Line ("Get_UInt32 from absolute index > position and <= high water mark");
+      Buffer.Put_String (String_Input);
+      Buffer.Put_UInt32 (UInt32_Input);
+      Buffer.Put_Byte (Byte_Input);
+
+      Buffer.Rewind;
+
+      Assert (Position (Buffer) = 0);
+      Assert (High_Water_Mark (Buffer) = Expected_High_Water_Mark);
+
+      --  now we read back one of the written values at an absolute position
+      --  that is greater than the current position but not greater than the
+      --  high water mark, which should succeed
+      declare
+         Output : UInt32;
+      begin
+         Buffer.Get_UInt32 (Output, First => Index_After_String);
+         pragma Assert (Output = UInt32_Input);
+      end;
+   end;
+
+--  inserting strings --------------------------------------------------------
+
+   declare
+      C : constant := 100; -- arbitrary
+      B : ByteBuffer (Capacity => C);
+      L : constant := C - 2;  -- leave room for length inserted into buffer too
+      S : constant String (1 .. L) := (others => 'x');
+   begin
+      Put_Line ("Inserting string with length < capacity");
+      B.Put_String (S);
+   end;
+
+   declare
+      C : constant := UInt16'Last;
+      B : ByteBuffer (Capacity => C + 2);
+      S : constant String (1 .. Integer (UInt16'Last)) := (others => 'x');
+   begin
+      Put_Line ("Inserting string with length = UInt16'Last, with sufficient capacity");
+      B.Put_String (S);
+   end;
+
+--  getting Strings ----------------------------------------------------------
+
+   declare
+      C : constant := 100; -- arbitrary
+      B : ByteBuffer (Capacity => C);
+      Corrupted_String_Length : constant := C + 1; -- anything > C will do
+      S : String (1 .. Corrupted_String_Length) := (others => ' ');
+      Last : Integer;
+      Unused : UInt32;
+   begin
+      Put_Line ("Getting string with stored length > remaining bytes in message");
+      --  Write a value that Get_String is going to read as the length of the
+      --  string in the message. The value must be > buffer capacity.
+      B.Put_UInt16 (Corrupted_String_Length);
+      --  Prepare to start getting values as if a message is in the buffer,
+      --  starting with a string. The actual characters are immaterial so we
+      --  don't bother to insert them into the buffer.
+      --
+      --  Note that this wouldn't happen without some sort of buffer
+      --  corruption because Put_String would have failed when attempting to
+      --  write that any chars into the buffer (since we know the buffer isn't
+      --  big enough in this test, on purpose).
+
+      B.Rewind;
+      B.Get_String (S, Last, Unused);
+      pragma Assert (B.Position = 2);
+      pragma Assert (Last = -1);
+   end;
+
+   -- the case in which stored length > string arg length AND we just set Last to -1
+   declare
+      C : constant := 10; -- arbitrary
+      B : ByteBuffer (Capacity => C);
+      Written : constant String (1 .. 8) := "helloyou";
+      Read : String (1 .. 5) := (others => ' ');
+      Last : Integer;
+      Stored_Length : UInt32;
+   begin
+      Put_Line ("Getting string with stored length > arg length");
+      B.Put_String (Written);
+      B.Rewind;
+      B.Get_String (Read, Last, Stored_Length);
+
+      pragma Assert (Last = -1);
+      pragma Assert (B.Position = 2);
+   end;
+
+   declare
+      C : constant := 100; -- arbitrary
+      B : ByteBuffer (Capacity => C);
+      Written : constant String (1 .. 5) := "world";
+      Read : String (1 .. 10) := (others => ' ');
+      Last : Integer;
+      Unused : UInt32;
+   begin
+      Put_Line ("Getting string with stored length < arg length");
+      B.Put_String (Written);
+      --  prepare to start getting values as if a message is in the buffer,
+      --  starting with a string
+      B.Rewind;
+      B.Get_String (Read, Last, Unused);
+      pragma Assert (Last = Written'Length);
+      pragma Assert (Read (1 .. Last) = Written);
+   end;
+
+--  writing unbounded strings -------------------------------------------------
+
+   declare
+      C : constant := 100; -- arbitrary
+      L : constant := C - 2;  -- leave room for length inserted into buffer too
+      B : ByteBuffer (Capacity => C);
+      S : constant ASU.Unbounded_String := ASU.To_Unbounded_String (Source => String'(1 .. L => 'x'));
+   begin
+      Put_Line ("Inserting unbounded string with length < capacity");
+      B.Put_Unbounded_String (S);
+   end;
+
+   declare
+      C : constant := 2;  -- the 2 bytes for the string's bounds
+      B : ByteBuffer (Capacity => C);
+      L : constant := 0;
+      S : constant ASU.Unbounded_String := ASU.To_Unbounded_String (Source => String'(1 .. L => 'x'));
+   begin
+      Put_Line ("Inserting unbounded string with length = 0, with sufficient capacity");
+      B.Put_Unbounded_String (S);
+   end;
+
+   declare
+      C : constant := 100; -- arbitrary
+      L : constant := C - 2;  -- leave room for length inserted into buffer too
+      B : ByteBuffer (Capacity => C);
+      S : constant ASU.Unbounded_String := ASU.To_Unbounded_String (Source => String'(1 .. L => 'x'));
+   begin
+      Put_Line ("Inserting unbounded string with length < capacity");
+      B.Put_Unbounded_String (S);
+   end;
+
+--  reading unbounded strings -------------------------------------------------
+
+   declare
+      C : constant := Max_String_Length;
+      B : ByteBuffer (Capacity => C + 2);
+      L : constant := Integer (C);
+      S : constant ASU.Unbounded_String := ASU.To_Unbounded_String (Source => String'(1 .. L => 'x'));
+      O : ASU.Unbounded_String := ASU.To_Unbounded_String (Length => L);
+      Num_Stored : UInt32;
+      use ASU;
+   begin
+      Put_Line ("Getting unbounded string with length = Max_String_Length, with sufficient capacity");
+      B.Put_Unbounded_String (S);
+      B.Rewind;
+      B.Get_Unbounded_String (O, Num_Stored);
+      pragma Assert (Num_Stored = Max_String_Length);
+      pragma Assert (O = S);
+   end;
+
+--  raw bytes ----------------------------------------------------------------
+
+   declare
+      C : constant := 100; -- arbitrary
+      B : ByteBuffer (Capacity => C);
+      L : constant := C - 2;  -- leave room for length inserted into buffer too
+      S : constant String (1 .. L) := (others => 'x');
+   begin
+      Put_Line ("Inserting raw bytes from String with length < capacity");
+      B.Put_Raw_Bytes (S);
+   end;
+
+   declare
+      C : constant := 100; -- arbitrary
+      B : ByteBuffer (Capacity => C);
+      L : constant := C - 2;  -- leave room for length inserted into buffer too
+      S : constant Byte_Array (1 .. L) := (others => Character'Pos ('x'));
+   begin
+      Put_Line ("Inserting raw bytes with length < capacity");
+      B.Put_Raw_Bytes (S);
+   end;
+
+   declare
+      C : constant := UInt32 (Positive'Last) + 10;
+      type ByteBuffer_Pointer is access ByteBuffer;
+      BBP : ByteBuffer_Pointer := new ByteBuffer (C);
+
+      L : constant := Positive'Last;
+      subtype Constrained_Byte_Array is Byte_Array (1 .. L);
+      type Byte_Array_Pointer is access Constrained_Byte_Array;
+      BAP : Byte_Array_Pointer := new Byte_Array'(1 .. L => Character'Pos ('x'));
+
+      procedure Free is new Ada.Unchecked_Deallocation
+        (Object => ByteBuffer, Name => ByteBuffer_Pointer);
+      procedure Free is new Ada.Unchecked_Deallocation
+        (Object => Constrained_Byte_Array, Name => Byte_Array_Pointer);
+   begin
+      Put_Line ("Inserting raw bytes with length = Positive'Last");
+      BBP.Put_Raw_Bytes (BAP.all);
+      --  and free them to keep SPARK happy
+      Free (BAP);
+      Free (BBP);
+   end;
+
+--  sequence of writes followed by sequence of reads  ------------------------
+
+   declare
+      Byte_Input    : constant Byte := 42;
+      String_Input  : constant String := "Hello World!";
+      UInt32_Input  : constant UInt32 := 42;
+      Real32_Input  : constant Real32 := 42.42;
+      Boolean_Input : constant Boolean := True;
+      UInt64_Input  : constant UInt64 := 84;
+
+      Buffer : ByteBuffer (Capacity => 1024);
+   begin
+      Put_Line ("Multiple writes folowed by reads of those written values");
+
+      --  NB: the order of the following must match the order of the calls to Get_* below
+      Buffer.Put_Byte (Byte_Input);
+      Buffer.Put_String (String_Input);
+      Buffer.Put_UInt32 (UInt32_Input);
+      Buffer.Put_Unbounded_String (ASU.To_Unbounded_String (String_Input));
+      Buffer.Put_Real32 (Real32_Input);
+      Buffer.Put_Boolean (Boolean_Input);
+      Buffer.Put_UInt64 (UInt64_Input);
+
+      --  now we read back what was written
+
+      Buffer.Rewind;
+
+      declare
+         Output : Byte;
+      begin
+         Buffer.Get_Byte (Output);
+         pragma Assert (Output = Byte_Input);
+      end;
+
+      declare
+         Output : String (String_Input'Range) := (others => ' ');
+         Last   : Integer;  -- because result can be -1 to signal a problem
+         Unused : UInt32;
+      begin
+         Buffer.Get_String (Output, Last, Unused);
+         pragma Assert (Last = String_Input'Length);
+         pragma Assert (Output (1 .. Last) = String_Input);
+      end;
+
+      declare
+         Output : UInt32;
+      begin
+         Buffer.Get_UInt32 (Output);
+         pragma Assert (Output = UInt32_Input);
+      end;
+
+      declare
+         Output : ASU.Unbounded_String;
+         Num_Stored : UInt32;
+      begin
+         Buffer.Get_Unbounded_String (Output, Num_Stored);
+         pragma Assert (Num_Stored = String_Input'Length);
+         pragma Assert (ASU.To_String (Output) = String_Input);
+      end;
+
+      declare
+         Output : Real32;
+      begin
+         Buffer.Get_Real32 (Output);
+         pragma Assert (Output = Real32_Input);
+      end;
+
+      declare
+         Output : Boolean;
+      begin
+         Buffer.Get_Boolean (Output);
+         pragma Assert (Output = Boolean_Input);
+      end;
+
+      declare
+         Output : UInt64;
+      begin
+         Buffer.Get_UInt64 (Output);
+         pragma Assert (Output = UInt64_Input);
+      end;
+   end;
+
+   Put_Line ("Done");  -- just in case you actually want to run this
+end Prove_ByteBuffers;

--- a/src/templates/ada/avtas/lmcp/test_bytebuffers.adb
+++ b/src/templates/ada/avtas/lmcp/test_bytebuffers.adb
@@ -15,14 +15,14 @@ begin
 
    declare
       C : constant := 100; -- arbitrary
-      B : ByteBuffer (Capacity => C);
+      Buffer : ByteBuffer (Capacity => C);
       V : UInt16 := 42;
    begin
       Put ("Get (first) value after rewind: ");
-      B.Put_Uint16 (V);
-      B.Rewind;
+      Put_Uint16 (Buffer, V);
+      Rewind (Buffer);
       V := 0;
-      B.Get_UInt16 (V);
+      Get_UInt16 (Buffer, V);
       if V = 42 then
          Put_Line ("passed");
       else
@@ -60,11 +60,11 @@ begin
       Buffer : ByteBuffer (Capacity => 100);
    begin
       Put ("Get_UInt32 from absolute index > position and <= high water mark: ");
-      Buffer.Put_String (String_Input);
-      Buffer.Put_UInt32 (UInt32_Input);
-      Buffer.Put_Byte (Byte_Input);
+      Put_String (Buffer, String_Input);
+      Put_UInt32 (Buffer, UInt32_Input);
+      Put_Byte (Buffer, Byte_Input);
 
-      Buffer.Rewind;
+      Rewind (Buffer);
 
       Assert (Position (Buffer) = 0, "Invalid position in test Get_UInt32 absolute");
       Assert (High_Water_Mark (Buffer) = Expected_High_Water_Mark, "Invalid high water mark in test Get_UInt32 absolute");
@@ -75,7 +75,7 @@ begin
       declare
          Output : UInt32;
       begin
-         Buffer.Get_UInt32 (Output, First => Index_After_String);
+         Get_UInt32 (Buffer, Output, First => Index_After_String);
          if Output = UInt32_Input then
             Put_Line ("passed");
          else
@@ -100,9 +100,9 @@ begin
       Buffer : ByteBuffer (Capacity => 100);
    begin
       Put ("Get_UInt32 from absolute index > position and > high water mark: ");
-      Buffer.Put_String (String_Input);
+      Put_String (Buffer, String_Input);
 
-      Buffer.Rewind;
+      Rewind (Buffer);
 
       Assert (Position (Buffer) = 0, "Invalid position in test Get_UInt32 absolute > high water mark");
       Assert (High_Water_Mark (Buffer) = Expected_High_Water_Mark,
@@ -112,7 +112,7 @@ begin
       declare
          Output : UInt32;
       begin
-         Buffer.Get_UInt32 (Output, First => Invalid_Index);
+         Get_UInt32 (Buffer, Output, First => Invalid_Index);
          Put_Line ("FAILED (should have raised Assertion_Error)");
          Failed := Failed + 1;
       exception
@@ -129,11 +129,11 @@ begin
 
    declare
       C : constant := 100; -- arbitrary
-      B : ByteBuffer (Capacity => C);
+      Buffer : ByteBuffer (Capacity => C);
       S : constant String (1 .. C + 1) := (others => 'x');
    begin
       Put ("Inserting string with length > capacity: ");
-      B.Put_String (S);
+      Put_String (Buffer, S);
       Put_Line ("FAILED (should have raised Assertion_Error)");
       Failed := Failed + 1;
    exception
@@ -146,12 +146,12 @@ begin
 
    declare
       C : constant := 100; -- arbitrary
-      B : ByteBuffer (Capacity => C);
+      Buffer : ByteBuffer (Capacity => C);
       L : constant := C - 2;  -- leave room for length inserted into buffer too
       S : constant String (1 .. L) := (others => 'x');
    begin
       Put ("Inserting string with length < capacity: ");
-      B.Put_String (S);
+      Put_String (Buffer, S);
       Put_Line ("passed");
    exception
       when Error : others =>
@@ -161,11 +161,11 @@ begin
 
    declare
       C : constant := Max_String_Length;
-      B : ByteBuffer (Capacity => C + 2);
+      Buffer : ByteBuffer (Capacity => C + 2);
       S : constant String (1 .. Max_String_Length + 1) := (others => 'x');
    begin
       Put ("Inserting string with length > Max_String_Length, with sufficient capacity: ");
-      B.Put_String (S);
+      Put_String (Buffer, S);
       Put_Line ("FAILED (should have raised Assertion_Error)");
       Failed := Failed + 1;
    exception
@@ -178,11 +178,11 @@ begin
 
    declare
       C : constant := Max_String_Length;
-      B : ByteBuffer (Capacity => C + 2);
+      Buffer : ByteBuffer (Capacity => C + 2);
       S : constant String (1 .. Max_String_Length) := (others => 'x');
    begin
       Put ("Inserting string with length = Max_String_Length, with sufficient capacity: ");
-      B.Put_String (S);
+      Put_String (Buffer, S);
       Put_Line ("passed");
    exception
       when Error : others =>
@@ -194,7 +194,7 @@ begin
 
    declare
       C : constant := 100; -- arbitrary
-      B : ByteBuffer (Capacity => C);
+      Buffer : ByteBuffer (Capacity => C);
       Corrupted_String_Length : constant := C + 1; -- anything > C will do
       S : String (1 .. Corrupted_String_Length);
       Last : Integer;
@@ -203,19 +203,19 @@ begin
       Put ("Getting string with stored length > remaining bytes in message: ");
       --  Write a value that Get_String is going to read as the length of the
       --  string in the message. The value must be > buffer capacity.
-      B.Put_UInt16 (Corrupted_String_Length);
+      Put_UInt16 (Buffer, Corrupted_String_Length);
       --  Prepare to start getting values as if a message is in the buffer,
       --  starting with a string. The actual characters are immaterial so we
-      --  don't bother to insert them into the buffer.
+      --  don't bother to insert them into the
       --
       --  Note that this wouldn't happen without some sort of buffer
       --  corruption because Put_String would have failed when attempting to
       --  write that any chars into the buffer (since we know the buffer isn't
       --  big enough in this test, on purpose).
 
-      B.Rewind;
-      B.Get_String (S, Last, Unused);
-      pragma Assert (B.Position = 2);
+      Rewind (Buffer);
+      Get_String (Buffer, S, Last, Unused);
+      pragma Assert (Position (Buffer) = 2);
       pragma Assert (Last = -1);
       Put_Line ("passed");
    exception
@@ -227,21 +227,21 @@ begin
    -- the case in which stored length > string arg length AND we just set Last to -1
    declare
       C : constant := 10; -- arbitrary
-      B : ByteBuffer (Capacity => C);
+      Buffer : ByteBuffer (Capacity => C);
       Written : constant String (1 .. 8) := "helloyou";
       Read : String (1 .. 5) := (others => ' ');
       Last : Integer;
       Stored_Length : UInt32;
    begin
       Put ("Getting string with stored length > arg length: ");
-      B.Put_String (Written);
-      B.Rewind;
-      B.Get_String (Read, Last, Stored_Length);
+      Put_String (Buffer, Written);
+      Rewind (Buffer);
+      Get_String (Buffer, Read, Last, Stored_Length);
 
       if Last /= -1 then
          Put_Line ("FAILED (incorrect value for Last)");
          Failed := Failed + 1;
-      elsif B.Position /= 2 then
+      elsif Position (Buffer) /= 2 then
          Put_Line ("FAILED (wrong Position)");
          Failed := Failed + 1;
       else
@@ -255,18 +255,18 @@ begin
 
    declare
       C : constant := 100; -- arbitrary
-      B : ByteBuffer (Capacity => C);
+      Buffer : ByteBuffer (Capacity => C);
       Written : constant String (1 .. 5) := "world";
       Read : String (1 .. 10) := (others => ' ');
       Last : Integer;
       Unused : UInt32;
    begin
       Put ("Getting string with stored length < arg length: ");
-      B.Put_String (Written);
+      Put_String (Buffer, Written);
       --  prepare to start getting values as if a message is in the buffer,
       --  starting with a string
-      B.Rewind;
-      B.Get_String (Read, Last, Unused);
+      Rewind (Buffer);
+      Get_String (Buffer, Read, Last, Unused);
 
       if Last /= Written'Length then
          Put_Line ("FAILED (incorrect value for Last)");
@@ -287,12 +287,12 @@ begin
 
    declare
       C : constant := 100; -- arbitrary
-      B : ByteBuffer (Capacity => C);
+      Buffer : ByteBuffer (Capacity => C);
       L : constant := C + 1;
       S : constant ASU.Unbounded_String := ASU.To_Unbounded_String (Source => String'(1 .. L => 'x'));
    begin
       Put ("Inserting unbounded string with length > capacity: ");
-      B.Put_Unbounded_String (S);
+      Put_Unbounded_String (Buffer, S);
       Put_Line ("FAILED (should have raised Assertion_Error)");
       Failed := Failed + 1;
    exception
@@ -306,11 +306,11 @@ begin
    declare
       C : constant := 100; -- arbitrary
       L : constant := C - 2;  -- leave room for length inserted into buffer too
-      B : ByteBuffer (Capacity => C);
+      Buffer : ByteBuffer (Capacity => C);
       S : constant ASU.Unbounded_String := ASU.To_Unbounded_String (Source => String'(1 .. L => 'x'));
    begin
       Put ("Inserting unbounded string with length < capacity: ");
-      B.Put_Unbounded_String (S);
+      Put_Unbounded_String (Buffer, S);
       Put_Line ("passed");
    exception
       when Error : others =>
@@ -320,12 +320,12 @@ begin
 
    declare
       C : constant := Max_String_Length;
-      B : ByteBuffer (Capacity => C + 2);
+      Buffer : ByteBuffer (Capacity => C + 2);
       L : constant := Integer (C) + 1;
       S : constant ASU.Unbounded_String := ASU.To_Unbounded_String (Source => String'(1 .. L => 'x'));
    begin
       Put ("Inserting unbounded string with length > Max_String_Length, with sufficient capacity: ");
-      B.Put_Unbounded_String (S);
+      Put_Unbounded_String (Buffer, S);
       Put_Line ("FAILED (should have raised Assertion_Error)");
       Failed := Failed + 1;
    exception
@@ -338,12 +338,12 @@ begin
 
    declare
       C : constant := 2;  -- the 2 bytes for the string's bounds
-      B : ByteBuffer (Capacity => C);
+      Buffer : ByteBuffer (Capacity => C);
       L : constant := 0;
       S : constant ASU.Unbounded_String := ASU.To_Unbounded_String (Source => String'(1 .. L => 'x'));
    begin
       Put ("Inserting unbounded string with length = 0, with sufficient capacity: ");
-      B.Put_Unbounded_String (S);
+      Put_Unbounded_String (Buffer, S);
       Put_Line ("passed");
    exception
       when Assertion_Error =>
@@ -356,12 +356,12 @@ begin
 
    declare
       C : constant := 1;  -- less than the 2 bytes for the string's bounds
-      B : ByteBuffer (Capacity => C);
+      Buffer : ByteBuffer (Capacity => C);
       L : constant := 0;
       S : constant ASU.Unbounded_String := ASU.To_Unbounded_String (Source => String'(1 .. L => 'x'));
    begin
       Put ("Inserting unbounded string with length = 0, without sufficient capacity: ");
-      B.Put_Unbounded_String (S);
+      Put_Unbounded_String (Buffer, S);
       Put_Line ("FAILED");  -- we didn't have room for the bounds
       Failed := Failed + 1;
    exception
@@ -375,11 +375,11 @@ begin
    declare
       C : constant := 100; -- arbitrary
       L : constant := C - 2;  -- leave room for length inserted into buffer too
-      B : ByteBuffer (Capacity => C);
+      Buffer : ByteBuffer (Capacity => C);
       S : constant ASU.Unbounded_String := ASU.To_Unbounded_String (Source => String'(1 .. L => 'x'));
    begin
       Put ("Inserting unbounded string with length < capacity: ");
-      B.Put_Unbounded_String (S);
+      Put_Unbounded_String (Buffer, S);
       Put_Line ("passed");
    exception
       when Error : others =>
@@ -391,7 +391,7 @@ begin
 
    declare
       C : constant := Max_String_Length;
-      B : ByteBuffer (Capacity => C + 2);
+      Buffer : ByteBuffer (Capacity => C + 2);
       L : constant := Integer (C);
       S : constant ASU.Unbounded_String := ASU.To_Unbounded_String (Source => String'(1 .. L => 'x'));
       O : ASU.Unbounded_String := ASU.To_Unbounded_String (Length => L);
@@ -399,9 +399,9 @@ begin
       use ASU;
    begin
       Put ("Getting unbounded string with length = Max_String_Length, with sufficient capacity: ");
-      B.Put_Unbounded_String (S);
-      B.Rewind;
-      B.Get_Unbounded_String (O, Num_Stored);
+      Put_Unbounded_String (Buffer, S);
+      Rewind (Buffer);
+      Get_Unbounded_String (Buffer, O, Num_Stored);
       if Num_Stored /= Max_String_Length then
          Put_Line ("FAILED (num stored mismatch)");
          Failed := Failed + 1;
@@ -421,11 +421,11 @@ begin
 
    declare
       C : constant := 100; -- arbitrary
-      B : ByteBuffer (Capacity => C);
+      Buffer : ByteBuffer (Capacity => C);
       S : constant String (1 .. C + 1) := (others => 'x');
    begin
       Put ("Inserting raw bytes from String with length > capacity: ");
-      B.Put_Raw_Bytes (S);
+      Put_Raw_Bytes (Buffer, S);
       Put_Line ("FAILED (should have raised Assertion_Error)");
       Failed := Failed + 1;
    exception
@@ -438,12 +438,12 @@ begin
 
    declare
       C : constant := 100; -- arbitrary
-      B : ByteBuffer (Capacity => C);
+      Buffer : ByteBuffer (Capacity => C);
       L : constant := C - 2;  -- leave room for length inserted into buffer too
       S : constant String (1 .. L) := (others => 'x');
    begin
       Put ("Inserting raw bytes from String with length < capacity: ");
-      B.Put_Raw_Bytes (S);
+      Put_Raw_Bytes (Buffer, S);
       Put_Line ("passed");
    exception
       when Error : others =>
@@ -452,11 +452,11 @@ begin
    end;
 
    declare
-      B : ByteBuffer (Capacity => Max_String_Length + 2);
+      Buffer : ByteBuffer (Capacity => Max_String_Length + 2);
       S : constant String (1 .. Max_String_Length + 1) := (others => 'x');
    begin
       Put ("Inserting raw bytes from String with length > Max_String_Length, with sufficient capacity: ");
-      B.Put_Raw_Bytes (S);
+      Put_Raw_Bytes (Buffer, S);
       Put_Line ("passed");
    exception
       when Error : others =>
@@ -466,12 +466,12 @@ begin
 
    declare
       C : constant := 100; -- arbitrary
-      B : ByteBuffer (Capacity => C);
+      Buffer : ByteBuffer (Capacity => C);
       L : constant := C - 2;  -- leave room for length inserted into buffer too
       S : constant Byte_Array (1 .. L) := (others => Character'Pos ('x'));
    begin
       Put ("Inserting raw bytes from Byte_Array with length < capacity: ");
-      B.Put_Raw_Bytes (S);
+      Put_Raw_Bytes (Buffer, S);
       Put_Line ("passed");
    exception
       when Error : others =>
@@ -490,7 +490,7 @@ begin
       Put ("Inserting raw bytes from Byte_Array with length = Positive'Last: ");
       --  note that this is the Put_Raw_Bytes that takes a Byte_Array, not a
       --  String, so there is no issue with Max_String_Length
-      BBP.Put_Raw_Bytes (BAP.all);
+      Put_Raw_Bytes (BBP.all, BAP.all);
       Put_Line ("passed");
    exception
       when Error : others =>
@@ -513,22 +513,22 @@ begin
       Put ("Multiple writes followed by reads of those written values: ");
 
       --  NB: the order of the following must match the order of the calls to Get_* below
-      Buffer.Put_Byte (Byte_Input);
-      Buffer.Put_String (String_Input);
-      Buffer.Put_UInt32 (UInt32_Input);
-      Buffer.Put_Unbounded_String (ASU.To_Unbounded_String (String_Input));
-      Buffer.Put_Real32 (Real32_Input);
-      Buffer.Put_Boolean (Boolean_Input);
-      Buffer.Put_UInt64 (UInt64_Input);
+      Put_Byte (Buffer, Byte_Input);
+      Put_String (Buffer, String_Input);
+      Put_UInt32 (Buffer, UInt32_Input);
+      Put_Unbounded_String (Buffer, ASU.To_Unbounded_String (String_Input));
+      Put_Real32 (Buffer, Real32_Input);
+      Put_Boolean (Buffer, Boolean_Input);
+      Put_UInt64 (Buffer, UInt64_Input);
 
       --  now we read back what was written
 
-      Buffer.Rewind;
+      Rewind (Buffer);
 
       declare
          Output : Byte;
       begin
-         Buffer.Get_Byte (Output);
+         Get_Byte (Buffer, Output);
          pragma Assert (Output = Byte_Input, "Getting Byte failed");
       end;
 
@@ -537,7 +537,7 @@ begin
          Last   : Natural;
          Unused : UInt32;
       begin
-         Buffer.Get_String (Output, Last, Unused);
+         Get_String (Buffer, Output, Last, Unused);
          pragma Assert (Last = String_Input'Length, "Getting string Last failed");
          pragma Assert (Output (1 .. Last) = String_Input, "Getting string failed");
       end;
@@ -545,7 +545,7 @@ begin
       declare
          Output : UInt32;
       begin
-         Buffer.Get_UInt32 (Output);
+         Get_UInt32 (Buffer, Output);
          pragma Assert (Output = UInt32_Input, "Getting UInt32 failed");
       end;
 
@@ -553,7 +553,7 @@ begin
          Output : ASU.Unbounded_String;
          Num_Stored : UInt32;
       begin
-         Buffer.Get_Unbounded_String (Output, Num_Stored);
+         Get_Unbounded_String (Buffer, Output, Num_Stored);
          pragma Assert (Num_Stored = String_Input'Length,  "Getting Unbounded_String failed (stored count mismatch)");
          pragma Assert (ASU.To_String (Output) = String_Input, "Getting Unbounded_String failed (content mismatch)");
       end;
@@ -561,21 +561,21 @@ begin
       declare
          Output : Real32;
       begin
-         Buffer.Get_Real32 (Output);
+         Get_Real32 (Buffer, Output);
          pragma Assert (Output = Real32_Input, "Getting Real32 failed");
       end;
 
       declare
          Output : Boolean;
       begin
-         Buffer.Get_Boolean (Output);
+         Get_Boolean (Buffer, Output);
          pragma Assert (Output = Boolean_Input, "Getting Boolean failed");
       end;
 
       declare
          Output : UInt64;
       begin
-         Buffer.Get_UInt64 (Output);
+         Get_UInt64 (Buffer, Output);
          pragma Assert (Output = UInt64_Input, "Getting UInt64 failed");
       end;
 

--- a/src/templates/ada/avtas/test_bytebuffers.gpr
+++ b/src/templates/ada/avtas/test_bytebuffers.gpr
@@ -15,8 +15,9 @@ project Test_ByteBuffers is
    for Object_Dir use "objs/" & Mode;
 
    Unconditional_Compiler_Switches :=
-     ("-gnatyO"      -- check that overriding subprograms are explicitly marked as such
-      , "-gnat2022"  -- enable Ada 2022
+     ("-gnatyO",       -- check that overriding subprograms are explicitly marked as such
+      "-gnatwJ",     -- suppress warnings on obsolescent features, esp. parentheses in aggregates
+      "-gnat2022"   -- enable Ada 2022
       );
 
    Debug_Switches := ("-g",

--- a/src/templates/ada/avtas/test_bytebuffers.gpr
+++ b/src/templates/ada/avtas/test_bytebuffers.gpr
@@ -2,7 +2,7 @@ project Test_ByteBuffers is
 
    for Source_Dirs use (".", "lmcp");
 
-   for Main use ("test_bytebuffers.adb");
+   for Main use ("prove_bytebuffers.adb", "test_bytebuffers.adb");
 
    type Modes is ("debug", "release");
    Mode : Modes := external ("Build", "debug");
@@ -15,7 +15,8 @@ project Test_ByteBuffers is
    for Object_Dir use "objs/" & Mode;
 
    Unconditional_Compiler_Switches :=
-     ("-gnatyO"    -- check that overriding subprograms are explicitly marked as such
+     ("-gnatyO"      -- check that overriding subprograms are explicitly marked as such
+      , "-gnat2022"  -- enable Ada 2022
       );
 
    Debug_Switches := ("-g",

--- a/src/templates/ada/avtas/test_bytebuffers.gpr
+++ b/src/templates/ada/avtas/test_bytebuffers.gpr
@@ -15,9 +15,9 @@ project Test_ByteBuffers is
    for Object_Dir use "objs/" & Mode;
 
    Unconditional_Compiler_Switches :=
-     ("-gnatyO",       -- check that overriding subprograms are explicitly marked as such
-      "-gnatwJ",     -- suppress warnings on obsolescent features, esp. parentheses in aggregates
-      "-gnat2022"   -- enable Ada 2022
+     ("-gnatyO",    -- check that overriding subprograms are explicitly marked as such
+      "-gnatwJ"    -- suppress warnings on obsolescent features, esp. parentheses in aggregates
+      --  "-gnat2022"   -- enable Ada 2022
       );
 
    Debug_Switches := ("-g",
@@ -59,9 +59,5 @@ project Test_ByteBuffers is
    package Builder is
       for Switches ("Ada") use ("-g");
    end Builder;
-
-   package Prove is
-      for Proof_Switches ("Ada") use ("--level=2", "--checks-as-errors", "--proof-warnings");
-   end Prove;
 
 end Test_ByteBuffers;

--- a/src/templates/ada/mdm-factory.adb
+++ b/src/templates/ada/mdm-factory.adb
@@ -17,12 +17,12 @@ package body -<full_series_name_dots>-.Factory is
       Buffer  : ByteBuffer (HEADER_SIZE + Index (MsgSize) + CHECKSUM_SIZE);
    begin
       -- add header values
-      Buffer.Put_Int32 (LMCP_CONTROL_STR);
-      Buffer.Put_UInt32 (MsgSize);
+      Put_Int32 (Buffer, LMCP_CONTROL_STR);
+      Put_UInt32 (Buffer, MsgSize);
       -- add root object
       PutObject (RootObject, Buffer);
       -- add checksum if enabled
-      Buffer.Put_UInt32 (if EnableChecksum then CalculatedChecksum (Buffer, Buffer.Capacity) else 0);
+      Put_UInt32 (Buffer, (if EnableChecksum then CalculatedChecksum (Buffer, High_Water_Mark (Buffer) - 1) else 0));
       return Buffer;
    end PackMessage;
 
@@ -34,12 +34,12 @@ package body -<full_series_name_dots>-.Factory is
    begin
       -- If object is null, pack a 0; otherwise, add root object
       if Object = null then
-         Buffer.Put_Boolean (False);
+         Put_Boolean (Buffer, False);
       else
-         Buffer.Put_Boolean (True);
-         Buffer.Put_Int64 (Object.GetSeriesNameAsLong);
-         Buffer.Put_UInt32 (Object.GetLmcpType);
-         Buffer.Put_UInt16 (Object.GetSeriesVersion);
+         Put_Boolean (Buffer, True);
+         Put_Int64 (Buffer, Object.GetSeriesNameAsLong);
+         Put_UInt32 (Buffer, Object.GetLmcpType);
+         Put_UInt16 (Buffer, Object.GetSeriesVersion);
          Object.Pack (Buffer);
       end if;
    end PutObject;
@@ -65,7 +65,7 @@ package body -<full_series_name_dots>-.Factory is
          --  return;
       end if;
       
-      Buffer.Get_Int32 (CtrlStr);
+      Get_Int32 (Buffer, CtrlStr);
       if CtrlStr /= LMCP_CONTROL_STR then
          Put_Line ("-<full_series_name_dots>-.Factory.GetObject error: Not a proper LMCP message.");
          Put_Line ("   Expected: " & LMCP_CONTROL_STR'Image & "   Received: " & CtrlStr'Image);
@@ -73,7 +73,7 @@ package body -<full_series_name_dots>-.Factory is
          --  return;
       end if;
       
-      Buffer.Get_UInt32 (MsgSize);
+      Get_UInt32 (Buffer, MsgSize);
       if Buffer.Capacity < Index (MsgSize) then
          Put_Line ("-<full_series_name_dots>-.Factory.GetObject error: Buffer size too small for packed object.");
          Put_Line ("   MsgSize: " & MsgSize'Image & "    Capacity: " & Buffer.Capacity'Image);
@@ -87,16 +87,16 @@ package body -<full_series_name_dots>-.Factory is
          --  return;
       end if;
       
-      Buffer.Get_Boolean (MsgExists);
+      Get_Boolean (Buffer, MsgExists);
       if not MsgExists then
          Put_Line ("-<full_series_name_dots>-.Factory.GetObject error: Message indicated it was packed as NULL");
          raise Program_Error;  -- for the moment
          --  return;
       end if;
 
-      Buffer.Get_Int64 (SeriesId);
-      Buffer.Get_UInt32 (MsgType);
-      Buffer.Get_UInt16 (Version);
+      Get_Int64 (Buffer, SeriesId);
+      Get_UInt32 (Buffer, MsgType);
+      Get_UInt16 (Buffer, Version);
       Output := CreateObject (SeriesId, MsgType, Version);
       if Output /= null then
          Output.Unpack (Buffer);
@@ -119,7 +119,7 @@ package body -<full_series_name_dots>-.Factory is
    ------------------------
 
    function CalculatedChecksum (Buffer : in ByteBuffer; Size : Index) return UInt32 is
-     (Buffer.Checksum (Last => Size - 1));
+     (Checksum (Buffer, Last => Size));
 
    -------------------
    -- GetObjectSize --
@@ -130,7 +130,7 @@ package body -<full_series_name_dots>-.Factory is
       Second_HalfWord_Start : constant Index := 4;  -- the buffer array is zero-based
    begin
       --  get the second UInt32 value in the buffer
-      Buffer.Get_UInt32 (Result, First => Second_HalfWord_Start);  
+      Get_UInt32 (Buffer, Result, First => Second_HalfWord_Start);  
       return Result;
    end getObjectSize;
 
@@ -141,12 +141,12 @@ package body -<full_series_name_dots>-.Factory is
    function Validated (Buffer : in ByteBuffer) return Boolean is
       Stored_Checksum : UInt32;
    begin
-      if Buffer.High_Water_Mark < HEADER_SIZE + CHECKSUM_SIZE then
+      if High_Water_Mark (Buffer) < HEADER_SIZE + CHECKSUM_SIZE then
          Put_Line ("-<full_series_name_dots>-.Factory.Validated: Buffer size < HEADER_SIZE + CHECKSUM_SIZE.");
          return False;
       end if;
-      Buffer.Get_UInt32 (Stored_Checksum, First => Buffer.High_Water_Mark - Checksum_Size);
-      return Stored_Checksum = 0 or else Stored_Checksum = CalculatedChecksum (Buffer, Buffer.High_Water_Mark - Checksum_Size);
+      Get_UInt32 (Buffer, Stored_Checksum, First => High_Water_Mark (Buffer) - Checksum_Size);
+      return Stored_Checksum = 0 or else Stored_Checksum = CalculatedChecksum (Buffer, High_Water_Mark (Buffer) - Checksum_Size);
    end Validated;
 
 end -<full_series_name_dots>-.Factory;

--- a/src/templates/ada/mdm-factory.ads
+++ b/src/templates/ada/mdm-factory.ads
@@ -12,9 +12,7 @@ package -<full_series_name_dots>-.Factory is
    function createObject(seriesId : in Int64;  msgType : in UInt32; version: in UInt16) return avtas.lmcp.object.Object_Any;
 
    function CalculatedChecksum (Buffer : in ByteBuffer; Size : Index) return UInt32;
-   --  Computes the modular checksum for the Buffer contents, ignoring the
-   --  last 4 bytes in which the checksum may or may not be stored. Assumes
-   --  Big Endian byte order.
+   --  Computes the modular checksum for the Buffer contents.
 
    function getObjectSize(buffer : in ByteBuffer) return UInt32;
 


### PR DESCRIPTION
avtas-lmcp-bytebuffers.ads and body: apply Relaxed_Initialization aspect and also correct omission
that Highest_Write_Pos must only be updated in Put_* routines if the newly updated
Position is going to exceed it

avtas-lmcp-bytebuffers-copying.ads: enhance postconditions on the two routines that copy
into a buffer, so that the now-conditional update to Highest_Write_Pos is expressed

avtas-lmcp-bytebuffers-copying-provable_adb: the two routines that copy into a buffer
are enhanced to support proof of initialization and the conditional update to Highest_Write_Pos

avtas-lmcp-bytebuffers-copying-performant_adb: remove SPARK_Mode since specification of 'Address
is not allowed in SPARK subset, and this version is not (yet) intended for proof

a-strunb.ads and conversion_equality_lemmas.ads: apply Always_Terminates

test_bytebuffers.gpr: remove unused and obsolete Proof package and its switches
